### PR TITLE
feat: add .mdx file support

### DIFF
--- a/src/utils/load-md-files.ts
+++ b/src/utils/load-md-files.ts
@@ -37,6 +37,6 @@ export const loadMdFiles = async (
 
   // 最后对获取的路径结果进行一次去重，防止重复的文件，同时只考虑 Markdown 文本
   return (uniq(filePaths.flat()) as string[]).filter((item) => {
-    return item.endsWith('.md') || item.endsWith('.markdown');
+    return item.endsWith('.md') || item.endsWith('.markdown') || item.endsWith('.mdx');
   });
 };

--- a/src/utils/load-md-files.ts
+++ b/src/utils/load-md-files.ts
@@ -36,6 +36,6 @@ export const loadMdFiles = async (
 
   // 最后对获取的路径结果进行一次去重，防止重复的文件，同时只考虑 Markdown 文本
   return ([...new Set(filePaths.flat())] as string[]).filter((item) => {
-    return item.endsWith('.md') || item.endsWith('.markdown');
+    return item.endsWith('.md') || item.endsWith('.markdown') || item.endsWith('.mdx');
   });
 };


### PR DESCRIPTION
Closes #20

在 `loadMdFiles` 的文件过滤条件中增加对 `.mdx` 扩展名的支持，用户可以通过传入 `**/*.mdx` 等 glob pattern 来 lint MDX 文件。

MDX 的核心语法是 Markdown，`@lint-md/core` 的 `lintMarkdown` 可以直接处理其 Markdown 部分，无需额外改动。