### PR TITLE
refactor: 移除 lodash、fs-extra 冗余依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,18 +51,14 @@
     "@lint-md/core": "^2.0.0",
     "chalk": "^4",
     "commander": "^9.4.1",
-    "fs-extra": "^10.1.0",
     "glob": "^8.0.3",
-    "lodash": "^4.17.21",
     "piscina": "^3.2.0",
     "strip-ansi": "^6.0.1",
     "text-table": "^0.2.0"
   },
   "devDependencies": {
-    "@types/fs-extra": "^9.0.13",
     "@types/glob": "^8.0.0",
     "@types/jest": "^29.2.1",
-    "@types/lodash": "^4.14.187",
     "@types/node": "^18.11.9",
     "eslint": "8.26.0",
     "jest": "^29.2.2",

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import * as process from 'process';
-import * as fs from 'fs-extra';
+import { writeFile } from 'fs/promises';
 import { program } from 'commander';
 import { batchLint } from './utils/batch-lint';
 import { getLintConfig, getThreadCount } from './utils/configure';
@@ -82,7 +82,7 @@ program
       else {
         for (const lintResultElement of lintResult) {
           const { path, fixedResult } = lintResultElement;
-          await fs.writeFile(path, fixedResult.result);
+          await writeFile(path, fixedResult.result);
         }
       }
     }

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -1,6 +1,6 @@
 import path from 'path';
+import { readFile } from 'fs/promises';
 import type { LintMdRulesConfig, lintMarkdown } from '@lint-md/core';
-import * as fs from 'fs-extra';
 // @ts-expect-error
 import { Piscina } from 'piscina';
 import type { LintWorkerOptions } from '../types';
@@ -21,7 +21,7 @@ export const batchLint = async (
   const fileContentList = await Promise.all(
     mdFilePaths.map((path) => {
       const call = async () => {
-        const res = await fs.readFile(path);
+        const res = await readFile(path);
         return {
           path,
           content: res.toString(),

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs';
 import { cpus } from 'os';
 import * as path from 'path';
 import chalk from 'chalk';
-import { merge } from 'lodash';
 import type { CLIConfig } from '../types';
 
 export const getLintConfig = (configFilePath: string): CLIConfig => {
@@ -34,13 +33,11 @@ export const getLintConfig = (configFilePath: string): CLIConfig => {
     }
   }
 
-  return merge(
-    {
-      excludeFiles: ['**/node_modules/**', '**/.git/**'],
-      rules: {},
-    },
-    config
-  );
+  return {
+    excludeFiles: ['**/node_modules/**', '**/.git/**'],
+    rules: {},
+    ...config,
+  };
 };
 
 export const getThreadCount = (threadCount: string | number | boolean) => {

--- a/src/utils/load-md-files.ts
+++ b/src/utils/load-md-files.ts
@@ -1,5 +1,4 @@
 import glob from 'glob';
-import { uniq } from 'lodash';
 
 const promisifyGlob = (pattern: string, options: glob.IOptions) => {
   return new Promise((resolve, reject) => {
@@ -27,7 +26,7 @@ export const loadMdFiles = async (
 ) => {
   const filePaths = await Promise.all(
     // 先把 globList 去重，防止执行多余的 glob 查询
-    uniq(globList).map((fileList) => {
+    [...new Set(globList)].map((fileList) => {
       return promisifyGlob(`${fileList}`, {
         ignore: excludeFiles,
         absolute: true,
@@ -36,7 +35,7 @@ export const loadMdFiles = async (
   );
 
   // 最后对获取的路径结果进行一次去重，防止重复的文件，同时只考虑 Markdown 文本
-  return (uniq(filePaths.flat()) as string[]).filter((item) => {
+  return ([...new Set(filePaths.flat())] as string[]).filter((item) => {
     return item.endsWith('.md') || item.endsWith('.markdown');
   });
 };


### PR DESCRIPTION
Close #23

## 改动内容

用 Node.js 原生 API 替换冗余依赖：

| 文件 | 改动 |
|---|---|
| `src/utils/configure.ts` | `lodash.merge` → 对象展开 |
| `src/utils/load-md-files.ts` | `lodash.uniq` → `[...new Set()]` |
| `src/utils/batch-lint.ts` | `fs-extra.readFile` → `fs/promises.readFile` |
| `src/lint-md.ts` | `fs-extra.writeFile` → `fs/promises.writeFile` |
| `package.json` | 移除 `lodash`、`fs-extra`、`@types/lodash`、`@types/fs-extra` |

## 效果

- 减少 4 个直接依赖
- 减少 5 个安装包
- 零功能变更，测试和 lint 通过