### PR TITLE
fix: 线程分组数动态计算，默认利用多核 CPU

### DIFF
--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -32,7 +32,7 @@ export const batchLint = async (
   );
 
   // 将 md 文件内容进行分组，供各个线程分配执行
-  const markdownContentGroup = averagedGroup(fileContentList, 10, (item) => {
+  const markdownContentGroup = averagedGroup(fileContentList, Math.max(threadsCount, 1), (item) => {
     return item.content.length;
   });
 

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -51,5 +51,5 @@ export const getThreadCount = (threadCount: string | number | boolean) => {
     return Number(threadCount);
   }
 
-  return threadCount ? cpus().length : 1;
+  return cpus().length;
 };


### PR DESCRIPTION
Close #25

## 问题

- 分组数硬编码为 10，`-t` 参数形同虚设
- 不指定 `-t` 时默认单线程，浪费多核 CPU

## 改动

| 文件 | 改动 |
|---|---|
| `src/utils/batch-lint.ts` | 分组数从 `10` → `Math.max(threadsCount, 1)` |
| `src/utils/configure.ts` | 默认线程数从 `1` → `cpus().length` |

## 行为变化

| 场景 | 改动前 | 改动后 |
|---|---|---|
| 不传 `-t` | 1 线程，1 分组 | N 线程（全部核心），N 分组 |
| `-t 4` | 4 线程，**10** 分组 | 4 线程，**4** 分组 |
| `-t` | N 线程，**10** 分组 | N 线程，**N** 分组 |