### PR TITLE
chore: npm 发布时移除 src 源码目录

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   },
   "files": [
     "esm",
-    "lib",
-    "src"
+    "lib"
   ],
   "keywords": [
     "lint",


### PR DESCRIPTION
Close #27

## 改动

`package.json` 中 `files` 字段移除 `"src"`，npm publish 只包含编译产物 `esm/` 和 `lib/`。