### PR TITLE
ci: 添加 Node.js 版本矩阵 (20/22/24)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,25 +1,39 @@
 name: build
 
-on: [ pull_request ]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   unit-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-node@v6.3.0
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Install modules
-        run: yarn install
+        run: npm install
 
       - name: Run tests
-        run: yarn test
+        run: npm test
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-node@v6.3.0
+        with:
+          node-version: 22
 
       - name: Install modules
-        run: yarn install
+        run: npm install
 
-      - name: Run tests
-        run: yarn lint
+      - name: Run lint
+        run: npm run lint


### PR DESCRIPTION
Close #29

## 改动

- `unit-test` job 添加 `strategy.matrix.node-version: [20, 22, 24]`
- 两个 job 添加 `actions/setup-node@v4`
- 触发条件加 `push: [master]`
- lint job 的 step 标签和命令修正