### PR TITLE
chore: 升级 piscina 3.2.0 → 5.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fs-extra": "^10.1.0",
     "glob": "^8.0.3",
     "lodash": "^4.17.21",
-    "piscina": "^3.2.0",
+    "piscina": "^5.1.4",
     "strip-ansi": "^6.0.1",
     "text-table": "^0.2.0"
   },

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import type { LintMdRulesConfig, lintMarkdown } from '@lint-md/core';
 import * as fs from 'fs-extra';
-// @ts-expect-error
 import { Piscina } from 'piscina';
 import type { LintWorkerOptions } from '../types';
 import { averagedGroup } from './averaged-group';


### PR DESCRIPTION
Close #31

## 改动

| 文件 | 改动 |
|---|---|
| `package.json` | `piscina` `^3.2.0` → `^5.1.4` |
| `src/utils/batch-lint.ts` | 移除 `@ts-expect-error`（v5 类型定义已修复） |

## 效果

- 净减少 7 个安装包
- Node 20/22/24 全兼容
- 测试和 lint 通过