### PR TITLE
feat(lint-md): add --stdin flag for reading markdown from standard input

### DIFF
--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -3,6 +3,7 @@
 import * as process from 'process';
 import { writeFile } from 'fs/promises';
 import { program } from 'commander';
+import { lintMarkdown } from '@lint-md/core';
 import { batchLint } from './utils/batch-lint';
 import { getLintConfig, getThreadCount } from './utils/configure';
 import type { CLIOptions } from './types';
@@ -10,6 +11,22 @@ import { loadMdFiles } from './utils/load-md-files';
 import { getReportData } from './utils/get-report-data';
 
 const { version } = require('../package.json');
+
+const readStdin = (): Promise<string> => {
+  return new Promise((resolve) => {
+    let content = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('readable', () => {
+      let chunk;
+      while ((chunk = process.stdin.read()) !== null) {
+        content += chunk;
+      }
+    });
+    process.stdin.on('end', () => {
+      resolve(content);
+    });
+  });
+};
 
 program
   .version(
@@ -33,13 +50,13 @@ program
     '-s, --suppress-warnings',
     'suppress all warnings, that means warnings will not block CI（抑制所有警告，这意味着警告不会阻止 CI）'
   )
+  .option(
+    '-i, --stdin',
+    'read markdown content from stdin（从标准输入中读取内容）'
+  )
   .arguments('[files...]')
   .action(async (files: string[], options: CLIOptions) => {
-    if (!files.length) {
-      return;
-    }
-
-    const { fix, config, threads, dev, suppressWarnings } = options;
+    const { fix, config, threads, dev, suppressWarnings, stdin } = options;
 
     const startTime = new Date().getTime();
     const isFixMode = Boolean(fix);
@@ -49,7 +66,50 @@ program
       console.log(`dev -- version: ${version}, ${new Date().toString()}`);
     }
 
-    const { rules, excludeFiles } = getLintConfig(config);
+    const { rules } = getLintConfig(config);
+
+    // Handle stdin mode
+    if (stdin) {
+      const content = await readStdin();
+
+      if (!content.trim()) {
+        console.log('🎉 No content to lint 🎉');
+        process.exit(0);
+        return;
+      }
+
+      try {
+        const result = lintMarkdown(content, rules, isFixMode);
+
+        if (isFixMode) {
+          process.stdout.write(result.fixedResult!.result);
+        }
+        else {
+          const { consoleMessage, errorCount, warningCount }
+            = getReportData([{ path: '(stdin)', lintResult: result.lintResult }]);
+
+          console.log(consoleMessage);
+
+          if (errorCount > 0 || (!suppressWarnings && warningCount !== 0)) {
+            process.exit(1);
+          }
+        }
+      }
+      catch (e) {
+        console.log(e);
+        process.exit(1);
+      }
+
+      const endTime = new Date().getTime();
+      console.log(`⌛️Done in ${endTime - startTime}ms.`);
+      return;
+    }
+
+    if (!files.length) {
+      return;
+    }
+
+    const { excludeFiles } = getLintConfig(config);
 
     const mdFiles = await loadMdFiles(files, excludeFiles);
 
@@ -74,7 +134,6 @@ program
 
         console.log(consoleMessage);
 
-        // 错误数目大于 0 或者没有抑制警告并且警告数目不为 0
         if (errorCount > 0 || (!suppressWarnings && warningCount !== 0)) {
           process.exit(1);
         }
@@ -96,6 +155,6 @@ program
 
 program.parse(process.argv);
 
-if (!program.args.length) {
+if (!program.args.length && !process.argv.includes('--stdin') && !process.argv.includes('-i')) {
   program.help();
 }

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -140,6 +140,7 @@ program
 
 program.parse(process.argv);
 
-if (!program.args.length && !process.argv.includes('--stdin') && !process.argv.includes('-i')) {
+const isStdin = process.argv.includes('--stdin') || process.argv.includes('-i');
+if (!program.args.length && !isStdin) {
   program.help();
 }

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -16,11 +16,8 @@ const readStdin = (): Promise<string> => {
   return new Promise((resolve) => {
     let content = '';
     process.stdin.setEncoding('utf8');
-    process.stdin.on('readable', () => {
-      let chunk;
-      while ((chunk = process.stdin.read()) !== null) {
-        content += chunk;
-      }
+    process.stdin.on('data', (chunk) => {
+      content += chunk;
     });
     process.stdin.on('end', () => {
       resolve(content);

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import * as process from 'process';
+import { readFileSync } from 'fs';
 import { writeFile } from 'fs/promises';
 import { program } from 'commander';
 import { lintMarkdown } from '@lint-md/core';
@@ -11,19 +12,6 @@ import { loadMdFiles } from './utils/load-md-files';
 import { getReportData } from './utils/get-report-data';
 
 const { version } = require('../package.json');
-
-const readStdin = (): Promise<string> => {
-  return new Promise((resolve) => {
-    let content = '';
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => {
-      content += chunk;
-    });
-    process.stdin.on('end', () => {
-      resolve(content);
-    });
-  });
-};
 
 program
   .version(
@@ -67,7 +55,7 @@ program
 
     // Handle stdin mode
     if (stdin) {
-      const content = await readStdin();
+      const content = readFileSync(process.stdin.fd, 'utf8');
 
       if (!content.trim()) {
         console.log('🎉 No content to lint 🎉');

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface CLIOptions {
   config?: string
   suppressWarnings: boolean
   threads?: string | boolean
+  stdin?: boolean
 }
 
 /** CLI lint 结果选项 */


### PR DESCRIPTION
Closes https://github.com/lint-md/lint-md/issues/104

## 变更内容

- `src/types.ts`: `CLIOptions` 新增 `stdin?: boolean`
- `src/lint-md.ts`: 
  - 新增 `-i, --stdin` CLI 选项
  - 标准输入模式下直接调用 `lintMarkdown` 进行 lint
  - 支持 `--fix` 模式将修复结果输出到 stdout
  - 空内容时正常退出，不显示帮助信息

## 使用方式

```bash
echo "hello ` world`" | lint-md --stdin
cat test.md | lint-md --stdin --fix
```