### PR TITLE
refactor: TypeScript 类型标注修复与 tsconfig 清理

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type { LintMdRulesConfig } from '@lint-md/core';
 
 export interface CLIConfig {
   excludeFiles?: string[]
-  rules: LintMdRulesConfig
+  rules?: LintMdRulesConfig
 }
 
 /** 用户传入的 CLI 选项 */
@@ -33,4 +33,19 @@ export interface LintWorkerOptions {
   rules?: LintMdRulesConfig
   isFixMode?: boolean
   isDev?: boolean
+}
+
+/** batchLint 单个文件的 lint 结果 */
+export interface BatchLintItem {
+  path: string
+  lintResult: {
+    loc: {
+      start: { line: number; column: number }
+      end: { line: number; column: number }
+    }
+    message: string
+    name: string
+    content: string
+    severity: number
+  }[]
 }

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -18,7 +18,7 @@ export const getLintConfig = (configFilePath: string): CLIConfig => {
 
   // 如果不存在文件直接返回空对象
   if (!fs.existsSync(configPath)) {
-    config = {} as any;
+    config = {};
   }
   else {
     try {

--- a/src/utils/get-report-data.ts
+++ b/src/utils/get-report-data.ts
@@ -1,14 +1,9 @@
 import chalk from 'chalk';
 import table from 'text-table';
 import stripAnsi from 'strip-ansi';
+import type { BatchLintItem } from '../types';
 
-/**
- * Given a word and a count, append an s if count is not one.
- * @param {string} word A word in its singular form.
- * @param {number} count A number controlling whether word should be pluralized.
- * @returns {string} The original word with an s on the end if count is not one.
- */
-function pluralize(word, count) {
+function pluralize(word: string, count: number): string {
   return count === 1 ? word : `${word}s`;
 }
 
@@ -28,8 +23,7 @@ interface Result {
   filePath: string
 }
 
-// TODO: 补充类型定义
-export const getReportData = (problemResult: any[]) => {
+export const getReportData = (problemResult: BatchLintItem[]) => {
   const results: Result[] = problemResult
     .map((res) => {
       const { path, lintResult } = res;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
       "node"
     ],
     "allowJs": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
     "sourceMap": true,
     "baseUrl": "./",
     "outDir": "lib"


### PR DESCRIPTION
## 改动

- `src/types.ts`: 新增 `BatchLintItem` 接口；`CLIConfig.rules` 改为可选
- `src/utils/get-report-data.ts`: 参数 `any[]` → `BatchLintItem[]`；`pluralize` 加类型标注；删除冗余 JSDoc
- `src/utils/configure.ts`: `config = {} as any` → `config = {}`
- `tsconfig.json`: 添加 `skipLibCheck: true`；删除未使用的 `experimentalDecorators`、`emitDecoratorMetadata`

## 验证

- [x] `npm run build` 通过
- [x] `npm test` 通过

Closes #34