### PR TITLE
fix: lint-md 错误处理、空值守卫及 configure 类型标注修复

### DIFF
--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -11,7 +11,7 @@ import type { CLIOptions } from './types';
 import { loadMdFiles } from './utils/load-md-files';
 import { getReportData } from './utils/get-report-data';
 
-const { version } = require('../package.json');
+import { version } from '../package.json';
 
 program
   .version(
@@ -43,7 +43,7 @@ program
   .action(async (files: string[], options: CLIOptions) => {
     const { fix, config, threads, dev, suppressWarnings, stdin } = options;
 
-    const startTime = new Date().getTime();
+    const startTime = Date.now();
     const isFixMode = Boolean(fix);
     const isDev = Boolean(dev);
 
@@ -51,7 +51,7 @@ program
       console.log(`dev -- version: ${version}, ${new Date().toString()}`);
     }
 
-    const { rules } = getLintConfig(config);
+    const { rules, excludeFiles, extensions } = getLintConfig(config);
 
     // Handle stdin mode
     if (stdin) {
@@ -66,8 +66,8 @@ program
       try {
         const result = lintMarkdown(content, rules, isFixMode);
 
-        if (isFixMode) {
-          process.stdout.write(result.fixedResult!.result);
+        if (isFixMode && result.fixedResult) {
+          process.stdout.write(result.fixedResult.result);
         }
         else {
           const { consoleMessage, errorCount, warningCount }
@@ -81,7 +81,7 @@ program
         }
       }
       catch (e) {
-        console.log(e);
+        console.error(e);
         process.exit(1);
       }
 
@@ -94,8 +94,6 @@ program
       return;
     }
 
-    const { excludeFiles, extensions } = getLintConfig(config);
-
     const mdFiles = await loadMdFiles(files, excludeFiles, extensions);
 
     if (!mdFiles.length) {
@@ -106,7 +104,7 @@ program
 
     try {
       const lintResult = await batchLint(
-        getThreadCount(threads),
+          getThreadCount(threads),
         mdFiles,
         isDev,
         isFixMode,
@@ -124,17 +122,19 @@ program
         }
       }
       else {
-        for (const lintResultElement of lintResult) {
-          const { path, fixedResult } = lintResultElement;
-          await writeFile(path, fixedResult.result);
-        }
+        await Promise.all(
+          lintResult.flatMap(({ path, fixedResult }) =>
+            fixedResult ? writeFile(path, fixedResult.result) : []
+          )
+        );
       }
     }
     catch (e) {
-      console.log(e);
+      console.error(e);
+      process.exit(1);
     }
 
-    const endTime = new Date().getTime();
+    const endTime = Date.now();
     console.log(`⌛️Done in ${endTime - startTime}ms.`);
   });
 

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import chalk from 'chalk';
 import type { CLIConfig } from '../types';
 
-export const getLintConfig = (configFilePath: string): CLIConfig => {
+export const getLintConfig = (configFilePath?: string): Required<CLIConfig> => {
   if (configFilePath && !fs.existsSync(configFilePath)) {
     console.log(
       chalk.red(`lint-md: Configure file '${configFilePath}' is not exist.`)
@@ -41,7 +41,7 @@ export const getLintConfig = (configFilePath: string): CLIConfig => {
   };
 };
 
-export const getThreadCount = (threadCount: string | number | boolean) => {
+export const getThreadCount = (threadCount?: string | number | boolean) => {
   if (typeof threadCount === 'number') {
     return threadCount;
   }


### PR DESCRIPTION
Close #38

## 修改内容

### `src/lint-md.ts`
- `require("../package.json")` → `import { version } from "../package.json"`
- stdin fix 模式 `result.fixedResult!.result` 加空值守卫
- 两处 catch 块补 `process.exit(1)`
- 错误输出 `console.log` → `console.error`
- 合并两次 `getLintConfig` 调用为一次
- fix 模式 for-of 串行写文件 → `Promise.all` 并行

### `src/utils/configure.ts`
- `getLintConfig` 返回类型 `CLIConfig` → `Required<CLIConfig>`，消除调用处 `| undefined` 传导
- `getThreadCount` 参数加 `?`，支持 `undefined`（commander -t 未传时）