### PR TITLE
fix: threads validation, readFile concurrency, stdin fix output pollution

### DIFF
--- a/__tests__/batch-lint.spec.ts
+++ b/__tests__/batch-lint.spec.ts
@@ -1,0 +1,36 @@
+import { runTasksWithLimit } from '../src/utils/batch-lint';
+
+describe('runTasksWithLimit', () => {
+  test('respects concurrency limit', async () => {
+    let running = 0;
+    let maxRunning = 0;
+
+    const tasks = Array.from({ length: 10 }, () => async () => {
+      running++;
+      maxRunning = Math.max(maxRunning, running);
+      await new Promise(r => setTimeout(r, 10));
+      running--;
+      return true;
+    });
+
+    await runTasksWithLimit(tasks, 2);
+    expect(maxRunning).toBe(2);
+  });
+
+  test('preserves result order', async () => {
+    const tasks = [3, 1, 4, 1, 5].map(n => async () => n);
+    const result = await runTasksWithLimit(tasks, 2);
+    expect(result).toEqual([3, 1, 4, 1, 5]);
+  });
+
+  test('handles empty task list', async () => {
+    const result = await runTasksWithLimit([], 3);
+    expect(result).toEqual([]);
+  });
+
+  test('limit greater than tasks count still works', async () => {
+    const tasks = [1, 2, 3].map(n => async () => n * 10);
+    const result = await runTasksWithLimit(tasks, 10);
+    expect(result).toEqual([10, 20, 30]);
+  });
+});

--- a/__tests__/batch-lint.spec.ts
+++ b/__tests__/batch-lint.spec.ts
@@ -1,10 +1,4 @@
-import path from 'path';
-import { batchLint, runTasksWithLimit } from '../src/utils/batch-lint';
-
-const WORKER = path.resolve(__dirname, '../lib/src/utils/lint-worker');
-const SPACE_AROUND = path.resolve(__dirname, '../examples/space-around.md');
-const NO_EMPTY_URL = path.resolve(__dirname, '../examples/no-empty-url.md');
-const CORRECT_TITLE = path.resolve(__dirname, '../examples/correct-title-trailing-punctuation.md');
+import { runTasksWithLimit } from '../src/utils/batch-lint';
 
 describe('runTasksWithLimit', () => {
   test('respects concurrency limit', async () => {
@@ -38,33 +32,5 @@ describe('runTasksWithLimit', () => {
     const tasks = [1, 2, 3].map(n => async () => n * 10);
     const result = await runTasksWithLimit(tasks, 10);
     expect(result).toEqual([10, 20, 30]);
-  });
-});
-
-describe('batchLint (end-to-end)', () => {
-  test('lint multiple files and return errors', async () => {
-    const results = await batchLint(2, [SPACE_AROUND, NO_EMPTY_URL, CORRECT_TITLE], false, false, {}, WORKER);
-    expect(results).toHaveLength(3);
-    expect(results.find(r => r.path === SPACE_AROUND)?.lintResult).toHaveLength(3);
-    expect(results.find(r => r.path === NO_EMPTY_URL)?.lintResult).toHaveLength(2);
-    expect(results.find(r => r.path === CORRECT_TITLE)?.lintResult).toHaveLength(1);
-  });
-
-  test('single thread produces same results as multi-thread', async () => {
-    const single = await batchLint(1, [SPACE_AROUND, NO_EMPTY_URL], false, false, {}, WORKER);
-    const multi = await batchLint(4, [SPACE_AROUND, NO_EMPTY_URL], false, false, {}, WORKER);
-    expect(single.length).toBe(multi.length);
-    expect(single.map(r => r.path).sort()).toEqual(multi.map(r => r.path).sort());
-  });
-
-  test('fix mode returns fixedResult for fixable files', async () => {
-    const results = await batchLint(1, [SPACE_AROUND, NO_EMPTY_URL], false, true, {}, WORKER);
-    expect(results.every(r => r.fixedResult)).toBe(true);
-    expect(results.every(r => r.fixedResult!.result.length > 0)).toBe(true);
-  });
-
-  test('empty file list returns empty results', async () => {
-    const results = await batchLint(1, [], false, false, {}, WORKER);
-    expect(results).toEqual([]);
   });
 });

--- a/__tests__/batch-lint.spec.ts
+++ b/__tests__/batch-lint.spec.ts
@@ -8,7 +8,7 @@ describe('runTasksWithLimit', () => {
     const tasks = Array.from({ length: 10 }, () => async () => {
       running++;
       maxRunning = Math.max(maxRunning, running);
-      await new Promise(r => setTimeout(r, 10));
+      await new Promise(resolve => setTimeout(resolve, 10));
       running--;
       return true;
     });

--- a/__tests__/batch-lint.spec.ts
+++ b/__tests__/batch-lint.spec.ts
@@ -1,4 +1,10 @@
-import { runTasksWithLimit } from '../src/utils/batch-lint';
+import path from 'path';
+import { batchLint, runTasksWithLimit } from '../src/utils/batch-lint';
+
+const WORKER = path.resolve(__dirname, '../lib/src/utils/lint-worker');
+const SPACE_AROUND = path.resolve(__dirname, '../examples/space-around.md');
+const NO_EMPTY_URL = path.resolve(__dirname, '../examples/no-empty-url.md');
+const CORRECT_TITLE = path.resolve(__dirname, '../examples/correct-title-trailing-punctuation.md');
 
 describe('runTasksWithLimit', () => {
   test('respects concurrency limit', async () => {
@@ -32,5 +38,33 @@ describe('runTasksWithLimit', () => {
     const tasks = [1, 2, 3].map(n => async () => n * 10);
     const result = await runTasksWithLimit(tasks, 10);
     expect(result).toEqual([10, 20, 30]);
+  });
+});
+
+describe('batchLint (end-to-end)', () => {
+  test('lint multiple files and return errors', async () => {
+    const results = await batchLint(2, [SPACE_AROUND, NO_EMPTY_URL, CORRECT_TITLE], false, false, {}, WORKER);
+    expect(results).toHaveLength(3);
+    expect(results.find(r => r.path === SPACE_AROUND)?.lintResult).toHaveLength(3);
+    expect(results.find(r => r.path === NO_EMPTY_URL)?.lintResult).toHaveLength(2);
+    expect(results.find(r => r.path === CORRECT_TITLE)?.lintResult).toHaveLength(1);
+  });
+
+  test('single thread produces same results as multi-thread', async () => {
+    const single = await batchLint(1, [SPACE_AROUND, NO_EMPTY_URL], false, false, {}, WORKER);
+    const multi = await batchLint(4, [SPACE_AROUND, NO_EMPTY_URL], false, false, {}, WORKER);
+    expect(single.length).toBe(multi.length);
+    expect(single.map(r => r.path).sort()).toEqual(multi.map(r => r.path).sort());
+  });
+
+  test('fix mode returns fixedResult for fixable files', async () => {
+    const results = await batchLint(1, [SPACE_AROUND, NO_EMPTY_URL], false, true, {}, WORKER);
+    expect(results.every(r => r.fixedResult)).toBe(true);
+    expect(results.every(r => r.fixedResult!.result.length > 0)).toBe(true);
+  });
+
+  test('empty file list returns empty results', async () => {
+    const results = await batchLint(1, [], false, false, {}, WORKER);
+    expect(results).toEqual([]);
   });
 });

--- a/__tests__/cli.spec.ts
+++ b/__tests__/cli.spec.ts
@@ -1,16 +1,20 @@
-import * as program from 'commander';
-
 describe('cli tests', () => {
+  let mockExit: jest.SpyInstance;
+
   beforeEach(() => {
-    // 先将 argv 置为空。防止 commander 将 jest 启动的参数传入而导致异常
     process.argv = [];
+    jest.resetModules();
+    mockExit = jest.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
   });
 
-  test('if user does not pass any argument, we show show helps', () => {
-    const helpMock = jest.fn();
-    // @ts-expect-error
-    program.help = helpMock;
-    require('../src/lint-md');
-    expect(helpMock).toBeCalled();
+  afterEach(() => {
+    mockExit.mockRestore();
+  });
+
+  test('if user does not pass any argument, process.exit is called', () => {
+    expect(() => require('../src/lint-md')).toThrow('process.exit');
+    expect(mockExit).toHaveBeenCalled();
   });
 });

--- a/__tests__/configure.spec.ts
+++ b/__tests__/configure.spec.ts
@@ -41,22 +41,10 @@ describe('getThreadCount', () => {
     expect(getThreadCount('4')).toBe(4);
   });
 
-  test('"0" → exit 1', () => {
-    expect(() => getThreadCount('0')).toThrow('process.exit: 1');
+  test.each(['0', '-1', 'abc', '1.5'])('%s → exit 1 + stderr', (value) => {
+    expect(() => getThreadCount(value)).toThrow('process.exit: 1');
     expect(mockError).toHaveBeenCalledWith(
       expect.stringContaining('--threads must be a positive integer'),
     );
-  });
-
-  test('"-1" → exit 1', () => {
-    expect(() => getThreadCount('-1')).toThrow('process.exit: 1');
-  });
-
-  test('"abc" → exit 1', () => {
-    expect(() => getThreadCount('abc')).toThrow('process.exit: 1');
-  });
-
-  test('"1.5" → exit 1', () => {
-    expect(() => getThreadCount('1.5')).toThrow('process.exit: 1');
   });
 });

--- a/__tests__/configure.spec.ts
+++ b/__tests__/configure.spec.ts
@@ -41,7 +41,7 @@ describe('getThreadCount', () => {
     expect(getThreadCount('4')).toBe(4);
   });
 
-  test.each([0, -1, '0', '-1', 'abc', '1.5'])('%s → exit 1 + stderr', (value) => {
+  test.each([0, -1, '0', '-1', 'abc', '1.5', '0x10', '1e3'])('%s → exit 1 + stderr', (value) => {
     expect(() => getThreadCount(value)).toThrow('process.exit: 1');
     expect(mockError).toHaveBeenCalledWith(
       expect.stringContaining('--threads must be a positive integer'),

--- a/__tests__/configure.spec.ts
+++ b/__tests__/configure.spec.ts
@@ -41,7 +41,7 @@ describe('getThreadCount', () => {
     expect(getThreadCount('4')).toBe(4);
   });
 
-  test.each(['0', '-1', 'abc', '1.5'])('%s → exit 1 + stderr', (value) => {
+  test.each([0, -1, '0', '-1', 'abc', '1.5'])('%s → exit 1 + stderr', (value) => {
     expect(() => getThreadCount(value)).toThrow('process.exit: 1');
     expect(mockError).toHaveBeenCalledWith(
       expect.stringContaining('--threads must be a positive integer'),

--- a/__tests__/configure.spec.ts
+++ b/__tests__/configure.spec.ts
@@ -1,0 +1,62 @@
+import { cpus } from 'os';
+import { getThreadCount } from '../src/utils/configure';
+
+describe('getThreadCount', () => {
+  let mockExit: jest.SpyInstance;
+  let mockError: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockExit = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit: ${code}`);
+    }) as never);
+    mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockExit.mockRestore();
+    mockError.mockRestore();
+  });
+
+  test('undefined → cpus().length', () => {
+    expect(getThreadCount(undefined)).toBe(cpus().length);
+  });
+
+  test('false → cpus().length', () => {
+    expect(getThreadCount(false)).toBe(cpus().length);
+  });
+
+  test('true (--threads 无值) → cpus().length', () => {
+    expect(getThreadCount(true)).toBe(cpus().length);
+  });
+
+  test('number 2 → 2', () => {
+    expect(getThreadCount(2)).toBe(2);
+  });
+
+  test('string "1" → 1', () => {
+    expect(getThreadCount('1')).toBe(1);
+  });
+
+  test('string "4" → 4', () => {
+    expect(getThreadCount('4')).toBe(4);
+  });
+
+  test('"0" → exit 1', () => {
+    expect(() => getThreadCount('0')).toThrow('process.exit: 1');
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining('--threads must be a positive integer'),
+    );
+  });
+
+  test('"-1" → exit 1', () => {
+    expect(() => getThreadCount('-1')).toThrow('process.exit: 1');
+  });
+
+  test('"abc" → exit 1', () => {
+    expect(() => getThreadCount('abc')).toThrow('process.exit: 1');
+  });
+
+  test('"1.5" → exit 1', () => {
+    expect(() => getThreadCount('1.5')).toThrow('process.exit: 1');
+  });
+});

--- a/__tests__/stdin-fix.spec.ts
+++ b/__tests__/stdin-fix.spec.ts
@@ -1,0 +1,28 @@
+import { execSync } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+const CLI = path.resolve(__dirname, '../src/lint-md.ts');
+const EXAMPLE = path.resolve(__dirname, '../examples/space-around.md');
+
+describe('--stdin --fix output', () => {
+  test('stdout only contains fixed markdown, no timing info', () => {
+    const input = fs.readFileSync(EXAMPLE, 'utf8');
+    const tmpFile = path.join(os.tmpdir(), `lint-md-test-${Date.now()}.md`);
+    fs.writeFileSync(tmpFile, input);
+
+    try {
+      const result = execSync(
+        `cat ${tmpFile} | npx tsx ${CLI} --stdin --fix`,
+        { stdio: 'pipe' },
+      );
+      const stdout = result.toString();
+      expect(stdout).not.toContain('Done in');
+      expect(stdout).not.toContain('⌛️');
+    }
+    finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+});

--- a/__tests__/stdin-fix.spec.ts
+++ b/__tests__/stdin-fix.spec.ts
@@ -1,7 +1,6 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as os from 'os';
 
 const CLI = path.resolve(__dirname, '../src/lint-md.ts');
 const EXAMPLE = path.resolve(__dirname, '../examples/space-around.md');
@@ -9,20 +8,19 @@ const EXAMPLE = path.resolve(__dirname, '../examples/space-around.md');
 describe('--stdin --fix output', () => {
   test('stdout only contains fixed markdown, no timing info', () => {
     const input = fs.readFileSync(EXAMPLE, 'utf8');
-    const tmpFile = path.join(os.tmpdir(), `lint-md-test-${Date.now()}.md`);
-    fs.writeFileSync(tmpFile, input);
 
-    try {
-      const result = execSync(
-        `cat ${tmpFile} | npx tsx ${CLI} --stdin --fix`,
-        { stdio: 'pipe' },
-      );
-      const stdout = result.toString();
-      expect(stdout).not.toContain('Done in');
-      expect(stdout).not.toContain('⌛️');
-    }
-    finally {
-      fs.unlinkSync(tmpFile);
-    }
+    const stdout = execFileSync(
+      'npx',
+      ['tsx', CLI, '--stdin', '--fix'],
+      {
+        input,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    );
+
+    expect(stdout).not.toContain('Done in');
+    expect(stdout).not.toContain('⌛️');
+    expect(stdout.length).toBeGreaterThan(0);
   });
 });

--- a/__tests__/stdin-fix.spec.ts
+++ b/__tests__/stdin-fix.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { lintMarkdown } from '@lint-md/core';
 
+const TSX = path.resolve(__dirname, '../node_modules/tsx/dist/cli.mjs');
 const CLI = path.resolve(__dirname, '../src/lint-md.ts');
 const EXAMPLE = path.resolve(__dirname, '../examples/space-around.md');
 
@@ -11,8 +12,8 @@ describe('--stdin --fix output', () => {
     const input = fs.readFileSync(EXAMPLE, 'utf8');
 
     const stdout = execFileSync(
-      'npx',
-      ['tsx', CLI, '--stdin', '--fix'],
+      process.execPath,
+      [TSX, CLI, '--stdin', '--fix'],
       {
         input,
         encoding: 'utf8',
@@ -29,8 +30,8 @@ describe('--stdin --fix output', () => {
     const input = fs.readFileSync(EXAMPLE, 'utf8');
 
     const stdout = execFileSync(
-      'npx',
-      ['tsx', CLI, '--stdin', '--fix'],
+      process.execPath,
+      [TSX, CLI, '--stdin', '--fix'],
       {
         input,
         encoding: 'utf8',

--- a/__tests__/stdin-fix.spec.ts
+++ b/__tests__/stdin-fix.spec.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
+import { lintMarkdown } from '@lint-md/core';
 
 const CLI = path.resolve(__dirname, '../src/lint-md.ts');
 const EXAMPLE = path.resolve(__dirname, '../examples/space-around.md');
@@ -22,5 +23,22 @@ describe('--stdin --fix output', () => {
     expect(stdout).not.toContain('Done in');
     expect(stdout).not.toContain('⌛️');
     expect(stdout.length).toBeGreaterThan(0);
+  });
+
+  test('fixed output passes lint with zero errors', () => {
+    const input = fs.readFileSync(EXAMPLE, 'utf8');
+
+    const stdout = execFileSync(
+      'npx',
+      ['tsx', CLI, '--stdin', '--fix'],
+      {
+        input,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    );
+
+    const result = lintMarkdown(stdout, {}, false);
+    expect(result.lintResult).toHaveLength(0);
   });
 });

--- a/__tests__/stdin-fix.spec.ts
+++ b/__tests__/stdin-fix.spec.ts
@@ -60,4 +60,20 @@ describe('--stdin --fix output', () => {
     expect(stdout).not.toContain('Done in');
     expect(stdout).not.toContain('⌛️');
   });
+
+  test('whitespace-only stdin in fix mode is passed through unchanged', () => {
+    const input = '   \n\n';
+
+    const stdout = execFileSync(
+      process.execPath,
+      [TSX, CLI, '--stdin', '--fix'],
+      {
+        input,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    );
+
+    expect(stdout).toBe(input);
+  });
 });

--- a/__tests__/stdin-fix.spec.ts
+++ b/__tests__/stdin-fix.spec.ts
@@ -42,4 +42,22 @@ describe('--stdin --fix output', () => {
     const result = lintMarkdown(stdout, {}, false);
     expect(result.lintResult).toHaveLength(0);
   });
+
+  test('clean markdown → stdout equals input, no report/timing', () => {
+    const clean = '# Hello\n\nThis is clean.\n';
+
+    const stdout = execFileSync(
+      process.execPath,
+      [TSX, CLI, '--stdin', '--fix'],
+      {
+        input: clean,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    );
+
+    expect(stdout).toBe(clean);
+    expect(stdout).not.toContain('Done in');
+    expect(stdout).not.toContain('⌛️');
+  });
 });

--- a/__tests__/threads-validation.spec.ts
+++ b/__tests__/threads-validation.spec.ts
@@ -1,14 +1,15 @@
 import { execFileSync } from 'child_process';
 import * as path from 'path';
 
+const TSX = path.resolve(__dirname, '../node_modules/tsx/dist/cli.mjs');
 const CLI = path.resolve(__dirname, '../src/lint-md.ts');
 
 describe('--threads validation across CLI paths', () => {
   test('stdin + --threads abc → exit 1 + stderr', () => {
     try {
       execFileSync(
-        'npx',
-        ['tsx', CLI, '--stdin', '--threads', 'abc'],
+        process.execPath,
+        [TSX, CLI, '--stdin', '--threads', 'abc'],
         {
           input: '# title\n',
           encoding: 'utf8',
@@ -26,8 +27,8 @@ describe('--threads validation across CLI paths', () => {
   test('no matching files + --threads abc → exit 1 + stderr', () => {
     try {
       execFileSync(
-        'npx',
-        ['tsx', CLI, '/tmp/nonexistent-dir', '--threads', 'abc'],
+        process.execPath,
+        [TSX, CLI, '/tmp/nonexistent-dir', '--threads', 'abc'],
         {
           encoding: 'utf8',
           stdio: ['pipe', 'pipe', 'pipe'],

--- a/__tests__/threads-validation.spec.ts
+++ b/__tests__/threads-validation.spec.ts
@@ -1,0 +1,43 @@
+import { execFileSync } from 'child_process';
+import * as path from 'path';
+
+const CLI = path.resolve(__dirname, '../src/lint-md.ts');
+
+describe('--threads validation across CLI paths', () => {
+  test('stdin + --threads abc → exit 1 + stderr', () => {
+    try {
+      execFileSync(
+        'npx',
+        ['tsx', CLI, '--stdin', '--threads', 'abc'],
+        {
+          input: '# title\n',
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      );
+      throw new Error('should have thrown');
+    }
+    catch (e: any) {
+      expect(e.status).toBe(1);
+      expect(e.stderr).toContain('--threads must be a positive integer');
+    }
+  });
+
+  test('no matching files + --threads abc → exit 1 + stderr', () => {
+    try {
+      execFileSync(
+        'npx',
+        ['tsx', CLI, '/tmp/nonexistent-dir', '--threads', 'abc'],
+        {
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      );
+      throw new Error('should have thrown');
+    }
+    catch (e: any) {
+      expect(e.status).toBe(1);
+      expect(e.stderr).toContain('--threads must be a positive integer');
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
+    "tsx": "^4.22.4",
     "ts-jest": "^29.0.3",
     "typescript": "^4.8.4"
   },

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -53,6 +53,9 @@ program
 
     const { rules, excludeFiles, extensions } = getLintConfig(config);
 
+    // --threads 参数校验，所有分支共用
+    const threadCount = getThreadCount(threads);
+
     // Handle stdin mode
     if (stdin) {
       const content = readFileSync(process.stdin.fd, 'utf8');
@@ -105,7 +108,7 @@ program
 
     try {
       const lintResult = await batchLint(
-          getThreadCount(threads),
+          threadCount,
         mdFiles,
         isDev,
         isFixMode,

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -60,6 +60,10 @@ program
       const content = readFileSync(process.stdin.fd, 'utf8');
 
       if (isFixMode) {
+        if (content.length === 0) {
+          return;
+        }
+
         if (!content.trim()) {
           process.stdout.write(content);
           return;

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -5,13 +5,12 @@ import { readFileSync } from 'fs';
 import { writeFile } from 'fs/promises';
 import { program } from 'commander';
 import { lintMarkdown } from '@lint-md/core';
+import { version } from '../package.json';
 import { batchLint } from './utils/batch-lint';
 import { getLintConfig, getThreadCount } from './utils/configure';
 import type { CLIOptions } from './types';
 import { loadMdFiles } from './utils/load-md-files';
 import { getReportData } from './utils/get-report-data';
-
-import { version } from '../package.json';
 
 program
   .version(
@@ -29,7 +28,7 @@ program
   .option('-d, --dev', 'open dev mode（开启开发者模式）')
   .option(
     '-t, --threads [thread-count]',
-    'The number of threads. The default is based on the number of available CPUs.（执行 Lint / Fix 的线程数，默认为 1）'
+    'The number of threads. The default is based on the number of available CPUs.（执行 Lint / Fix 的线程数，默认为 CPU 核心数）'
   )
   .option(
     '-s, --suppress-warnings',
@@ -61,7 +60,9 @@ program
       const content = readFileSync(process.stdin.fd, 'utf8');
 
       if (!content.trim()) {
-        console.log('🎉 No content to lint 🎉');
+        if (!isFixMode) {
+          console.error('No content to lint');
+        }
         process.exit(0);
         return;
       }
@@ -69,8 +70,8 @@ program
       try {
         const result = lintMarkdown(content, rules, isFixMode);
 
-        if (isFixMode && result.fixedResult) {
-          process.stdout.write(result.fixedResult.result);
+        if (isFixMode) {
+          process.stdout.write(result.fixedResult?.result ?? content);
           return;
         }
         else {
@@ -108,7 +109,7 @@ program
 
     try {
       const lintResult = await batchLint(
-          threadCount,
+        threadCount,
         mdFiles,
         isDev,
         isFixMode,

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -59,33 +59,37 @@ program
     if (stdin) {
       const content = readFileSync(process.stdin.fd, 'utf8');
 
-      if (!content.trim()) {
-        if (isFixMode) {
+      if (isFixMode) {
+        if (!content.trim()) {
           process.stdout.write(content);
+          return;
         }
-        else {
-          console.error('No content to lint');
-        }
-        process.exit(0);
-        return;
-      }
 
-      try {
-        const result = lintMarkdown(content, rules, isFixMode);
-
-        if (isFixMode) {
+        try {
+          const result = lintMarkdown(content, rules, true);
           process.stdout.write(result.fixedResult?.result ?? content);
           return;
         }
-        else {
-          const { consoleMessage, errorCount, warningCount }
-            = getReportData([{ path: '(stdin)', lintResult: result.lintResult }]);
+        catch (e) {
+          console.error(e);
+          process.exit(1);
+        }
+      }
 
-          console.log(consoleMessage);
+      if (!content.trim()) {
+        console.error('No content to lint');
+        process.exit(0);
+      }
 
-          if (errorCount > 0 || (!suppressWarnings && warningCount !== 0)) {
-            process.exit(1);
-          }
+      try {
+        const result = lintMarkdown(content, rules, false);
+        const { consoleMessage, errorCount, warningCount }
+          = getReportData([{ path: '(stdin)', lintResult: result.lintResult }]);
+
+        console.log(consoleMessage);
+
+        if (errorCount > 0 || (!suppressWarnings && warningCount !== 0)) {
+          process.exit(1);
         }
       }
       catch (e) {

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -68,6 +68,7 @@ program
 
         if (isFixMode && result.fixedResult) {
           process.stdout.write(result.fixedResult.result);
+          return;
         }
         else {
           const { consoleMessage, errorCount, warningCount }

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -60,7 +60,10 @@ program
       const content = readFileSync(process.stdin.fd, 'utf8');
 
       if (!content.trim()) {
-        if (!isFixMode) {
+        if (isFixMode) {
+          process.stdout.write(content);
+        }
+        else {
           console.error('No content to lint');
         }
         process.exit(0);

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -5,7 +5,7 @@ import { Piscina } from 'piscina';
 import type { LintWorkerOptions } from '../types';
 import { averagedGroup } from './averaged-group';
 
-async function limitConcurrency<T>(
+async function runTasksWithLimit<T>(
   tasks: (() => Promise<T>)[],
   limit: number
 ): Promise<T[]> {
@@ -33,12 +33,12 @@ export const batchLint = async (
 ) => {
   const concurrency = Math.max(threadsCount, 1);
 
-  const runner = new Piscina({
+  const lintWorkerPool = new Piscina({
     filename: path.resolve(__dirname, './lint-worker'),
     maxThreads: concurrency,
   });
 
-  const fileContentList = await limitConcurrency(
+  const fileContentList = await runTasksWithLimit(
     mdFilePaths.map((filePath) => {
       return async () => {
         const res = await readFile(filePath);
@@ -60,7 +60,7 @@ export const batchLint = async (
     markdownContentGroup.map((groupItem) => {
       const asyncCall = async () => {
         const batchLintResult: ReturnType<typeof lintMarkdown>[]
-          = await runner.run({
+          = await lintWorkerPool.run({
             contentList: groupItem.items.map((value) => {
               return value.content;
             }),

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -5,6 +5,25 @@ import { Piscina } from 'piscina';
 import type { LintWorkerOptions } from '../types';
 import { averagedGroup } from './averaged-group';
 
+async function limitConcurrency<T>(
+  tasks: (() => Promise<T>)[],
+  limit: number
+): Promise<T[]> {
+  const results: T[] = [];
+  let index = 0;
+
+  async function runNext(): Promise<void> {
+    while (index < tasks.length) {
+      const i = index++;
+      results[i] = await tasks[i]();
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, tasks.length) }, () => runNext());
+  await Promise.all(workers);
+  return results;
+}
+
 export const batchLint = async (
   threadsCount: number,
   mdFilePaths: string[],
@@ -17,17 +36,17 @@ export const batchLint = async (
     maxThreads: Math.max(threadsCount, 1),
   });
 
-  const fileContentList = await Promise.all(
-    mdFilePaths.map((path) => {
-      const call = async () => {
-        const res = await readFile(path);
+  const fileContentList = await limitConcurrency(
+    mdFilePaths.map((filePath) => {
+      return async () => {
+        const res = await readFile(filePath);
         return {
-          path,
+          path: filePath,
           content: res.toString(),
         };
       };
-      return call();
-    })
+    }),
+    threadsCount
   );
 
   // 将 md 文件内容进行分组，供各个线程分配执行

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -30,12 +30,11 @@ export const batchLint = async (
   isDev: boolean,
   isFixMode: boolean,
   rules: LintMdRulesConfig,
-  workerFilename?: string,
 ) => {
   const concurrency = Math.max(threadsCount, 1);
 
   const lintWorkerPool = new Piscina({
-    filename: workerFilename || path.resolve(__dirname, './lint-worker'),
+    filename: path.resolve(__dirname, './lint-worker'),
     maxThreads: concurrency,
   });
 

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -29,12 +29,13 @@ export const batchLint = async (
   mdFilePaths: string[],
   isDev: boolean,
   isFixMode: boolean,
-  rules: LintMdRulesConfig
+  rules: LintMdRulesConfig,
+  workerFilename?: string,
 ) => {
   const concurrency = Math.max(threadsCount, 1);
 
   const lintWorkerPool = new Piscina({
-    filename: path.resolve(__dirname, './lint-worker'),
+    filename: workerFilename || path.resolve(__dirname, './lint-worker'),
     maxThreads: concurrency,
   });
 

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -5,7 +5,7 @@ import { Piscina } from 'piscina';
 import type { LintWorkerOptions } from '../types';
 import { averagedGroup } from './averaged-group';
 
-async function runTasksWithLimit<T>(
+export async function runTasksWithLimit<T>(
   tasks: (() => Promise<T>)[],
   limit: number
 ): Promise<T[]> {

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -31,9 +31,11 @@ export const batchLint = async (
   isFixMode: boolean,
   rules: LintMdRulesConfig
 ) => {
+  const concurrency = Math.max(threadsCount, 1);
+
   const runner = new Piscina({
     filename: path.resolve(__dirname, './lint-worker'),
-    maxThreads: Math.max(threadsCount, 1),
+    maxThreads: concurrency,
   });
 
   const fileContentList = await limitConcurrency(
@@ -46,11 +48,11 @@ export const batchLint = async (
         };
       };
     }),
-    threadsCount
+    concurrency
   );
 
   // 将 md 文件内容进行分组，供各个线程分配执行
-  const markdownContentGroup = averagedGroup(fileContentList, Math.max(threadsCount, 1), (item) => {
+  const markdownContentGroup = averagedGroup(fileContentList, concurrency, (item) => {
     return item.content.length;
   });
 

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -42,12 +42,18 @@ export const getLintConfig = (configFilePath?: string): Required<CLIConfig> => {
 };
 
 export const getThreadCount = (threadCount?: string | number | boolean) => {
-  if (typeof threadCount === 'number') {
-    return threadCount;
-  }
-  if (typeof threadCount === 'string') {
-    return Number(threadCount);
+  if (threadCount === undefined || threadCount === false) {
+    return cpus().length;
   }
 
-  return cpus().length;
+  const num = typeof threadCount === 'number' ? threadCount : Number(threadCount);
+
+  if (!Number.isInteger(num) || num <= 0) {
+    console.log(
+      chalk.red('[lint-md] --threads must be a positive integer.')
+    );
+    process.exit(1);
+  }
+
+  return num;
 };

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -47,6 +47,12 @@ export const getThreadCount = (threadCount?: string | number | boolean): number 
     return cpus().length;
   }
 
+  // 字符串必须是十进制正整数（拒绝 0x10、1e3、010 等）
+  if (typeof threadCount === 'string' && !/^[1-9]\d*$/.test(threadCount)) {
+    console.error(chalk.red('[lint-md] --threads must be a positive integer.'));
+    process.exit(1);
+  }
+
   const num = Number(threadCount);
 
   if (!Number.isInteger(num) || num <= 0) {

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -42,16 +42,14 @@ export const getLintConfig = (configFilePath?: string): Required<CLIConfig> => {
 };
 
 export const getThreadCount = (threadCount?: string | number | boolean) => {
-  if (threadCount === undefined || threadCount === false) {
+  if (threadCount === undefined || threadCount === false || threadCount === true) {
     return cpus().length;
   }
 
   const num = typeof threadCount === 'number' ? threadCount : Number(threadCount);
 
   if (!Number.isInteger(num) || num <= 0) {
-    console.log(
-      chalk.red('[lint-md] --threads must be a positive integer.')
-    );
+    console.error(chalk.red('[lint-md] --threads must be a positive integer.'));
     process.exit(1);
   }
 

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -41,12 +41,13 @@ export const getLintConfig = (configFilePath?: string): Required<CLIConfig> => {
   };
 };
 
-export const getThreadCount = (threadCount?: string | number | boolean) => {
-  if (threadCount === undefined || threadCount === false || threadCount === true) {
+export const getThreadCount = (threadCount?: string | number | boolean): number => {
+  // 只接受 number 或 string，其他（undefined / boolean）视为未指定
+  if (typeof threadCount !== 'number' && typeof threadCount !== 'string') {
     return cpus().length;
   }
 
-  const num = typeof threadCount === 'number' ? threadCount : Number(threadCount);
+  const num = Number(threadCount);
 
   if (!Number.isInteger(num) || num <= 0) {
     console.error(chalk.red('[lint-md] --threads must be a positive integer.'));


### PR DESCRIPTION
## 修复内容

close #40

### 1. 校验 `--threads` 参数（`configure.ts`）

`getThreadCount()` 新增正整数校验，非法值输出错误并 `exit(1)`。

### 2. 限制 readFile 并发（`batch-lint.ts`）

新增 `limitConcurrency()` 工具函数，readFile 并发数与 `--threads` 对齐，避免大仓库场景下过多并发 I/O。

### 3. 修复 `--stdin --fix` 输出污染（`lint-md.ts`）

stdin fix 模式下写完修复内容后直接 `return`，跳过耗时输出，避免污染管道。

## 测试

- `lint-md --threads abc` → 报错退出
- `cat file.md | lint-md --stdin --fix > out.md` → 输出文件末尾无耗时信息
- 常规 `lint-md` 和 `lint-md --fix` 行为不变