### PR TITLE
fix(test): suppress Jest haste collision warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
+    "modulePathIgnorePatterns": ["<rootDir>/esm/", "<rootDir>/lib/"],
     "collectCoverage": true,
     "collectCoverageFrom": [
       "src/**/*.{js,jsx,ts,tsx}",


### PR DESCRIPTION
Closes #52

Add `modulePathIgnorePatterns: ["<rootDir>/esm/", "<rootDir>/lib/"]` to Jest config to suppress the haste collision warning caused by build output sharing the same module name as the root package.

- [x] Warning no longer appears in test output
- [x] 25/25 tests passed