### PR TITLE
feat(lint-md): limit --fix write concurrency using runTasksWithLimit

### DIFF
--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -6,7 +6,7 @@ import { writeFile } from 'fs/promises';
 import { program } from 'commander';
 import { lintMarkdown } from '@lint-md/core';
 import { version } from '../package.json';
-import { batchLint } from './utils/batch-lint';
+import { batchLint, runTasksWithLimit } from './utils/batch-lint';
 import { getLintConfig, getThreadCount } from './utils/configure';
 import type { CLIOptions } from './types';
 import { loadMdFiles } from './utils/load-md-files';
@@ -138,10 +138,11 @@ program
         }
       }
       else {
-        await Promise.all(
-          lintResult.flatMap(({ path, fixedResult }) =>
-            fixedResult ? writeFile(path, fixedResult.result) : []
-          )
+        await runTasksWithLimit(
+          lintResult
+            .filter(({ fixedResult }) => fixedResult)
+            .map(({ path, fixedResult }) => () => writeFile(path, fixedResult!.result)),
+          threadCount
         );
       }
     }


### PR DESCRIPTION
close #54

当前 `--fix` 模式使用 `Promise.all` 无限制并发写入所有文件，大批量 fix 时可能打满 I/O。

复用已有的 `runTasksWithLimit`，将写入并发限制为 `threadCount`（默认 CPU 核心数），与读取/lint 并发统一。

## 改动

- `src/lint-md.ts`：导入 `runTasksWithLimit`，替换 `Promise.all` 为有并发限制的写入

## 验证

- Build 通过
- 25 个测试全绿