### PR TITLE
fix: prevent symlink overwrites in --fix mode

### DIFF
--- a/__tests__/symlink-security.spec.ts
+++ b/__tests__/symlink-security.spec.ts
@@ -1,0 +1,66 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { safeWriteFile } from '../src/utils/safe-write-file';
+import { loadMdFiles } from '../src/utils/load-md-files';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-md-symlink-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('symlink security', () => {
+  test('safeWriteFile writes to regular file', async () => {
+    const filePath = path.join(tmpDir, 'normal.md');
+    fs.writeFileSync(filePath, '# old');
+
+    await safeWriteFile(filePath, '# new');
+
+    expect(fs.readFileSync(filePath, 'utf8')).toBe('# new');
+  });
+
+  test('loadMdFiles filters .md symlinks', async () => {
+    const realFile = path.join(tmpDir, 'real.md');
+    const symlinkFile = path.join(tmpDir, 'link.md');
+    fs.writeFileSync(realFile, '# real');
+    fs.symlinkSync(realFile, symlinkFile);
+
+    const result = await loadMdFiles([path.join(tmpDir, '*.md')], []);
+
+    expect(result).toContain(realFile);
+    expect(result).not.toContain(symlinkFile);
+  });
+
+  test('safeWriteFile rejects symlink', async () => {
+    const target = path.join(tmpDir, 'target.md');
+    const symlink = path.join(tmpDir, 'link.md');
+    fs.writeFileSync(target, '# target');
+    fs.symlinkSync(target, symlink);
+
+    await expect(safeWriteFile(symlink, '# hacked'))
+      .rejects.toThrow(/ELOOP|ENOENT/);
+  });
+
+  test('safeWriteFile rejects file replaced with symlink after scan', async () => {
+    const filePath = path.join(tmpDir, 'file.md');
+    const target = path.join(tmpDir, 'target.md');
+    fs.writeFileSync(filePath, '# original');
+    fs.writeFileSync(target, '# target');
+
+    // Simulate TOCTOU: scan sees regular file, then attacker replaces with symlink
+    const stat = fs.lstatSync(filePath);
+    expect(stat.isFile()).toBe(true);
+
+    // Replace with symlink
+    fs.unlinkSync(filePath);
+    fs.symlinkSync(target, filePath);
+
+    await expect(safeWriteFile(filePath, '# hacked'))
+      .rejects.toThrow(/ELOOP|ENOENT/);
+  });
+});

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -2,10 +2,10 @@
 
 import * as process from 'process';
 import { readFileSync } from 'fs';
-import { writeFile } from 'fs/promises';
 import { program } from 'commander';
 import { lintMarkdown } from '@lint-md/core';
 import { version } from '../package.json';
+import { safeWriteFile } from './utils/safe-write-file';
 import { batchLint, runTasksWithLimit } from './utils/batch-lint';
 import { getLintConfig, getThreadCount } from './utils/configure';
 import type { CLIOptions } from './types';
@@ -141,7 +141,7 @@ program
         await runTasksWithLimit(
           lintResult
             .filter(({ fixedResult }) => fixedResult)
-            .map(({ path, fixedResult }) => () => writeFile(path, fixedResult!.result)),
+            .map(({ path, fixedResult }) => () => safeWriteFile(path, fixedResult!.result)),
           threadCount
         );
       }

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -31,7 +31,7 @@ export const batchLint = async (
   isFixMode: boolean,
   rules: LintMdRulesConfig,
 ) => {
-  const concurrency = Math.max(threadsCount, 1);
+  const concurrency = Math.min(Math.max(threadsCount, 1), mdFilePaths.length);
 
   const lintWorkerPool = new Piscina({
     filename: path.resolve(__dirname, './lint-worker'),

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -31,6 +31,10 @@ export const batchLint = async (
   isFixMode: boolean,
   rules: LintMdRulesConfig,
 ) => {
+  if (mdFilePaths.length === 0) {
+    return [];
+  }
+
   const concurrency = Math.min(Math.max(threadsCount, 1), mdFilePaths.length);
 
   const lintWorkerPool = new Piscina({

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { cpus } from 'os';
+import { availableParallelism } from 'os';
 import * as path from 'path';
 import chalk from 'chalk';
 import type { CLIConfig } from '../types';
@@ -44,7 +44,7 @@ export const getLintConfig = (configFilePath?: string): Required<CLIConfig> => {
 export const getThreadCount = (threadCount?: string | number | boolean): number => {
   // 只接受 number 或 string，其他（undefined / boolean）视为未指定
   if (typeof threadCount !== 'number' && typeof threadCount !== 'string') {
-    return cpus().length;
+    return availableParallelism();
   }
 
   // 字符串必须是十进制正整数（拒绝 0x10、1e3、010 等）

--- a/src/utils/load-md-files.ts
+++ b/src/utils/load-md-files.ts
@@ -1,3 +1,4 @@
+import { lstat } from 'fs/promises';
 import { glob } from 'glob';
 
 /**
@@ -18,12 +19,29 @@ export const loadMdFiles = async (
       return glob(`${fileList}`, {
         ignore: excludeFiles,
         absolute: true,
+        nodir: true,
+        follow: false,
       });
     })
   );
 
-  // 最后对获取的路径结果进行一次去重，防止重复的文件，同时只考虑 Markdown 文本
-  return ([...new Set(filePaths.flat())] as string[]).filter((item) => {
+  const filtered = ([...new Set(filePaths.flat())] as string[]).filter((item) => {
     return extensions.some(ext => item.endsWith(ext));
   });
+
+  // lstat 过滤：跳过符号链接，只忽略 ENOENT，其他错误继续抛出
+  const stats = await Promise.all(
+    filtered.map(async (f) => {
+      try {
+        return await lstat(f);
+      }
+      catch (e: any) {
+        if (e.code === 'ENOENT')
+          return null;
+        throw e;
+      }
+    })
+  );
+
+  return filtered.filter((_, i) => stats[i] !== null && !stats[i]!.isSymbolicLink());
 };

--- a/src/utils/safe-write-file.ts
+++ b/src/utils/safe-write-file.ts
@@ -1,0 +1,23 @@
+import { constants } from 'fs';
+import { open } from 'fs/promises';
+
+/**
+ * 安全写入文件，拒绝符号链接
+ *
+ * 使用 O_NOFOLLOW 防止最终路径是符号链接，
+ * 打开后通过 fstat 验证句柄指向普通文件，解决 TOCTOU 竞态。
+ */
+export async function safeWriteFile(filePath: string, content: string) {
+  const handle = await open(filePath, constants.O_WRONLY | constants.O_NOFOLLOW);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new Error(`Refusing to write non-regular file: ${filePath}`);
+    }
+    await handle.truncate(0);
+    await handle.writeFile(content, 'utf8');
+  }
+  finally {
+    await handle.close();
+  }
+}


### PR DESCRIPTION
## Summary

Closes #58

Two-layer defense against symlink exploitation in `--fix` mode:

1. **Scan stage**: `loadMdFiles` now uses glob `nodir: true` + `follow: false`, and filters symlinks via `lstat`
2. **Write stage**: New `safeWriteFile` utility uses `O_NOFOLLOW` + `handle.stat()` (fstat) to reject symlinks at write time

Also fixes `batch-lint.ts` to cap concurrency at file count, avoiding empty workers.

## Changes

- `src/utils/safe-write-file.ts` (new): Symlink-safe write with `O_NOFOLLOW` and fstat
- `src/utils/load-md-files.ts`: Add glob options + lstat symlink filter
- `src/lint-md.ts`: Replace `writeFile` with `safeWriteFile` in fix mode
- `src/utils/batch-lint.ts`: Cap concurrency at `mdFilePaths.length`
- `__tests__/symlink-security.spec.ts` (new): 4 test cases covering normal write, symlink filtering, symlink rejection, and TOCTOU

## Testing

- 29/29 tests pass
- 4 new symlink security tests
- Lint clean

## Notes

- Parent directory symlinks are out of scope (glob v13 limitation)
- Behavioral change: users who intentionally lint symlinks will see them filtered out
- Use `os.availableParallelism()` instead of `cpus().length` for default thread count