### PR TITLE
fix(safe-write-file): replace truncate-then-write with write-then-truncate

### DIFF
--- a/__tests__/symlink-security.spec.ts
+++ b/__tests__/symlink-security.spec.ts
@@ -63,4 +63,25 @@ describe('symlink security', () => {
     await expect(safeWriteFile(filePath, '# hacked'))
       .rejects.toThrow(/ELOOP|ENOENT/);
   });
+
+  test('safeWriteFile preserves original file mode', async () => {
+    const filePath = path.join(tmpDir, 'mode-test.md');
+    fs.writeFileSync(filePath, '# old');
+    fs.chmodSync(filePath, 0o666);
+
+    await safeWriteFile(filePath, '# new');
+
+    const mode = fs.statSync(filePath).mode & 0o777;
+    expect(mode).toBe(0o666);
+    expect(fs.readFileSync(filePath, 'utf8')).toBe('# new');
+  });
+
+  test('safeWriteFile truncates old tail when new content is shorter', async () => {
+    const filePath = path.join(tmpDir, 'shorter.md');
+    fs.writeFileSync(filePath, '# old content with tail');
+
+    await safeWriteFile(filePath, '# new');
+
+    expect(fs.readFileSync(filePath, 'utf8')).toBe('# new');
+  });
 });

--- a/src/utils/safe-write-file.ts
+++ b/src/utils/safe-write-file.ts
@@ -2,20 +2,50 @@ import { constants } from 'fs';
 import { open } from 'fs/promises';
 
 /**
- * 安全写入文件，拒绝符号链接
+ * 安全写入文件，拒绝符号链接。
  *
- * 使用 O_NOFOLLOW 防止最终路径是符号链接，
- * 打开后通过 fstat 验证句柄指向普通文件，解决 TOCTOU 竞态。
+ * 保留 in-place update 语义，避免 temp-file + rename 改变文件身份、
+ * inode、hard link、birthtime、owner、ACL、xattr 等属性。
+ *
+ * 写入顺序为 write-then-truncate：
+ * 先从 offset 0 写入完整新内容，再截断到新长度，避免 truncate(0)
+ * 在写入失败时把文件直接变成空文件。
+ *
+ * 注意：这不是完全原子写入；崩溃时仍可能出现部分新内容或旧尾部残留。
  */
 export async function safeWriteFile(filePath: string, content: string) {
-  const handle = await open(filePath, constants.O_WRONLY | constants.O_NOFOLLOW);
+  const handle = await open(
+    filePath,
+    constants.O_RDWR | constants.O_NOFOLLOW
+  );
+
   try {
     const stat = await handle.stat();
+
     if (!stat.isFile()) {
       throw new Error(`Refusing to write non-regular file: ${filePath}`);
     }
-    await handle.truncate(0);
-    await handle.writeFile(content, 'utf8');
+
+    const buf = Buffer.from(content, 'utf8');
+
+    let written = 0;
+    while (written < buf.length) {
+      const { bytesWritten } = await handle.write(
+        buf,
+        written,
+        buf.length - written,
+        written
+      );
+
+      if (bytesWritten === 0) {
+        throw new Error(`Failed to write file: ${filePath}`);
+      }
+
+      written += bytesWritten;
+    }
+
+    await handle.truncate(buf.length);
+    await handle.sync();
   }
   finally {
     await handle.close();


### PR DESCRIPTION
Closes #67

## 变更

- 保留 in-place update 语义，不再使用 temp-file + rename 替换文件
- `O_WRONLY` 改为 `O_RDWR`，继续使用 `O_NOFOLLOW`
- 将 `truncate(0) → write` 改为 `write from offset 0 → truncate(newLength)`
- `handle.write()` 改为循环写入，不假设一次写完全部 buffer
- 写入后调用 `handle.sync()`，请求将文件内容和 size 元数据刷盘

## 改进点

消除 `truncate(0)` 成功但写入失败时，目标文件变成空文件的最坏情况。

相比 temp-file + rename，本方案保留 in-place update 语义，更符合 `lint-md --fix` 对修改原文件的用户预期。它能保留 inode / hard link / owner / ACL / xattr / birthtime 等文件身份相关属性；mtime / ctime 会按正常文件修改语义更新。

## 仍不保证

- 不是完全原子写入；崩溃时可能出现部分新内容或旧尾部残留
- 不提供跨文件事务
- 不额外处理极端掉电或文件系统异常场景

## 测试

- 39 项测试通过，lint 和 build 通过
- 新增 mode 保留测试、短内容尾部截断测试