### PR TITLE
[codex] Add batch lint memory benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "build": "rm -rf esm lib && run-p build:*",
     "clean": "rm -rf lib esm",
     "watch": "tsc -w",
-    "cli-run": "node ./lib/src/lint-md.js examples/correct-title-trailing-punctuation.md"
+    "cli-run": "node ./lib/src/lint-md.js examples/correct-title-trailing-punctuation.md",
+    "benchmark:memory": "node scripts/benchmark-memory.mjs",
+    "test:benchmark-memory": "node scripts/benchmark-memory-smoke.mjs"
   },
   "files": [
     "esm/package.json",

--- a/scripts/benchmark-memory-smoke.mjs
+++ b/scripts/benchmark-memory-smoke.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const benchmark = path.join(scriptsDir, 'benchmark-memory.mjs');
+const result = spawnSync(
+  process.execPath,
+  [
+    benchmark,
+    '--files',
+    '2',
+    '--bytes-per-file',
+    '1024',
+    '--threads',
+    '1',
+  ],
+  {
+    encoding: 'utf8',
+  }
+);
+
+const output = `${result.stdout}${result.stderr}`;
+
+if (result.status !== 0 || !output.includes('Maximum resident set size')) {
+  process.stderr.write(output);
+  process.exit(result.status ?? 1);
+}
+
+console.log('memory benchmark smoke OK');

--- a/scripts/benchmark-memory.mjs
+++ b/scripts/benchmark-memory.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const timeCommand = '/usr/bin/time';
+
+const usage = `Usage: node scripts/benchmark-memory.mjs [options]
+
+Options:
+  --files <count>            Number of generated Markdown files (default: 8)
+  --bytes-per-file <bytes>   Approximate bytes per file (default: 65536)
+  --threads <count>          lint-md worker count (default: 2)
+  --runs <count>             Number of benchmark repetitions (default: 1)
+  --fix                      Benchmark fix mode
+  -h, --help                 Show this help
+`;
+
+const parsePositiveInteger = (value, option) => {
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw new Error(`${option} must be a positive integer`);
+  }
+
+  return Number(value);
+};
+
+const parseArgs = (args) => {
+  const options = {
+    files: 8,
+    bytesPerFile: 65536,
+    threads: 2,
+    runs: 1,
+    fix: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '-h' || arg === '--help') {
+      console.log(usage);
+      process.exit(0);
+    }
+
+    if (arg === '--fix') {
+      options.fix = true;
+      continue;
+    }
+
+    const value = args[index + 1];
+    if (value === undefined) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    if (arg === '--files') {
+      options.files = parsePositiveInteger(value, arg);
+    }
+    else if (arg === '--bytes-per-file') {
+      options.bytesPerFile = parsePositiveInteger(value, arg);
+    }
+    else if (arg === '--threads') {
+      options.threads = parsePositiveInteger(value, arg);
+    }
+    else if (arg === '--runs') {
+      options.runs = parsePositiveInteger(value, arg);
+    }
+    else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+
+    index += 1;
+  }
+
+  return options;
+};
+
+if (!existsSync(timeCommand)) {
+  throw new Error('/usr/bin/time is required for this Linux memory benchmark');
+}
+
+const options = parseArgs(process.argv.slice(2));
+const fixtureDir = mkdtempSync(path.join(tmpdir(), 'lint-md-memory-'));
+
+try {
+  const prefix = '# Title\n\n';
+  const bodyLength = Math.max(options.bytesPerFile - prefix.length - 1, 0);
+  const body = 'word '.repeat(Math.ceil(bodyLength / 5)).slice(0, bodyLength);
+  const content = `${prefix}${body}\n`;
+  const filePaths = [];
+
+  for (let index = 0; index < options.files; index += 1) {
+    const filePath = path.join(fixtureDir, `fixture-${index}.md`);
+    writeFileSync(filePath, content);
+    filePaths.push(filePath);
+  }
+
+  const tsx = path.join(rootDir, 'node_modules/tsx/dist/cli.mjs');
+  const cli = path.join(rootDir, 'src/lint-md.ts');
+  const cliArgs = [
+    '-v',
+    process.execPath,
+    tsx,
+    cli,
+    '--threads',
+    String(options.threads),
+  ];
+
+  if (options.fix) {
+    cliArgs.push('--fix');
+  }
+
+  cliArgs.push(...filePaths);
+
+  const benchmarkConfig = {
+    files: options.files,
+    bytesPerFile: content.length,
+    totalInputBytes: content.length * options.files,
+    threads: options.threads,
+    fix: options.fix,
+    runs: options.runs,
+  };
+  const measurements = [];
+
+  console.log(JSON.stringify({ type: 'config', ...benchmarkConfig }));
+
+  for (let run = 1; run <= options.runs; run += 1) {
+    const result = spawnSync(timeCommand, cliArgs, {
+      cwd: rootDir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LC_ALL: 'C',
+      },
+      maxBuffer: 10 * 1024 * 1024,
+    });
+
+    process.stdout.write(result.stdout);
+    process.stderr.write(result.stderr);
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    if (result.status !== 0) {
+      process.exitCode = result.status ?? 1;
+      break;
+    }
+
+    const rssMatch = result.stderr.match(
+      /Maximum resident set size \(kbytes\): (\d+)/
+    );
+    const elapsedMatch = result.stderr.match(
+      /Elapsed \(wall clock\) time \(h:mm:ss or m:ss\): ([\d:.]+)/
+    );
+
+    measurements.push({
+      run,
+      maxRssKiB: rssMatch ? Number(rssMatch[1]) : null,
+      elapsed: elapsedMatch?.[1] ?? null,
+    });
+  }
+
+  console.log(JSON.stringify({
+    type: 'summary',
+    ...benchmarkConfig,
+    measurements,
+  }));
+}
+finally {
+  rmSync(fixtureDir, { recursive: true, force: true });
+}

--- a/scripts/benchmark-memory.mjs
+++ b/scripts/benchmark-memory.mjs
@@ -16,6 +16,8 @@ const timeCommand = '/usr/bin/time';
 
 const usage = `Usage: node scripts/benchmark-memory.mjs [options]
 
+Linux only: requires GNU /usr/bin/time -v.
+
 Options:
   --files <count>            Number of generated Markdown files (default: 8)
   --bytes-per-file <bytes>   Approximate bytes per file (default: 65536)
@@ -82,8 +84,15 @@ const parseArgs = (args) => {
   return options;
 };
 
+if (process.platform !== 'linux') {
+  throw new Error(
+    `Unsupported platform: ${process.platform}. `
+    + 'This benchmark currently requires GNU time on Linux.'
+  );
+}
+
 if (!existsSync(timeCommand)) {
-  throw new Error('/usr/bin/time is required for this Linux memory benchmark');
+  throw new Error('GNU /usr/bin/time is required for this Linux benchmark');
 }
 
 const options = parseArgs(process.argv.slice(2));


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

- add a Linux peak-memory benchmark for batch lint
- generate temporary Markdown fixtures with configurable size and worker count
- support repeated runs with machine-readable RSS and elapsed-time summaries
- add a small smoke test and npm commands
- reject unsupported platforms with a clear error

## Why

Batch lint currently loads all Markdown content before linting. This PR establishes a repeatable baseline before the production data path is changed in a later PR.

## Baseline

Node.js 24.15.0, 16 files, 1,000,010 bytes per file, three runs per worker setting:

| Threads | Median peak RSS | RSS range | Median wall time | Time range |
|---:|---:|---:|---:|---:|
| 1 | 972,620 KiB | 971,028–1,051,080 KiB | 11.17s | 9.87–11.45s |
| 4 | 2,452,408 KiB | 2,198,368–2,570,680 KiB | 4.38s | 4.08–4.48s |

## Platform scope

This benchmark intentionally supports Linux with GNU /usr/bin/time -v. macOS uses BSD time with different flags, output fields, and units. macOS support is left to a volunteer contribution that can include BSD output fixtures, unit-conversion tests, and real-device verification.

## Impact

No production source or CLI behavior changes. The benchmark removes its temporary fixtures in a finally block.

## Validation

- npm test -- --runInBand: 45 tests passed
- npm run build: passed
- npx eslint --ext .ts,.tsx ./: passed
- npm run test:benchmark-memory: passed
- node --check scripts/benchmark-memory.mjs: passed
- invalid --runs 0: exited non-zero
- git diff --check: passed

Closes #69