### PR TITLE
chore(core): upgrade @lint-md/core to 2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     ]
   },
   "dependencies": {
-    "@lint-md/core": "^2.1.3",
+    "@lint-md/core": "^2.1.4",
     "chalk": "^4",
     "commander": "^9.4.1",
     "glob": "^13.0.6",


### PR DESCRIPTION
## Summary
- Bump `@lint-md/core` from `^2.1.3` to `^2.1.4` in `package.json`.
- 2.1.4 contains only internal rule fixes (e.g. `no-long-code`); the public API / type definitions are unchanged, so no source changes are required in this CLI.

## Verification
- `npm install` resolves `@lint-md/core@2.1.4`.
- `npm run build` (tsc cjs + esm) passes.
- `npm test`: 9 suites / 89 tests pass.

🤖 Generated with [opencode](https://opencode.ai)