### PR TITLE
refactor(types): reuse @lint-md/core LintReportItem / FixedResult

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 /** CLI 配置 */
-import type { LintMdRulesConfig } from '@lint-md/core';
+import type { LintMdRulesConfig, LintReportItem, FixedResult } from '@lint-md/core';
 
 export type ThreadCount = number | 'auto';
 
@@ -42,22 +42,6 @@ export interface LintWorkerOptions {
 /** batchLint 单个文件的 lint 结果 */
 export interface BatchLintItem {
   path: string
-  lintResult: {
-    loc: {
-      start: { line: number; column: number }
-      end: { line: number; column: number }
-    }
-    message: string
-    name: string
-    content: string
-    severity: number
-  }[]
-  fixedResult?: {
-    result: string
-    notAppliedFixes: {
-      range: number[]
-      text: string
-      data?: Record<string, unknown>
-    }[]
-  } | null
+  lintResult: LintReportItem[]
+  fixedResult?: FixedResult | null
 }


### PR DESCRIPTION
Closes #84.

## Summary
- Replace the hand-written `BatchLintItem.lintResult` / `fixedResult` shapes in `src/types.ts` with `@lint-md/core`'s exported `LintReportItem` and `FixedResult` types (available since core 2.1.4, shipped via #87).
- Pure type-level refactor — no runtime or behavior change.

## Verification
- `npm run build` (tsc cjs + esm) passes.
- `npm test`: 9 suites / 89 tests pass.
- Usages in `get-report-data.ts` (`loc.start`, `message`, `severity`, `name`) and `lint-worker.ts` (`result.lintResult`, `result.fixedResult`) are type-compatible with the new shapes.

🤖 Generated with [opencode](https://opencode.ai)