### PR TITLE
fix(batch-lint): keep files with notAppliedFixes (#86)

### DIFF
--- a/__tests__/batch-lint.spec.ts
+++ b/__tests__/batch-lint.spec.ts
@@ -3,7 +3,14 @@ import { availableParallelism, tmpdir } from 'os';
 import * as path from 'path';
 import { Piscina } from 'piscina';
 import type { LintMdRulesConfig } from '@lint-md/core';
-import { STAT_CONCURRENCY_LIMIT, batchLint, getMaxFileSize, resolveAdaptiveConcurrency, runTasksWithLimit } from '../src/utils/batch-lint';
+import { STAT_CONCURRENCY_LIMIT, batchLint, getMaxFileSize, keepLintItem, resolveAdaptiveConcurrency, runTasksWithLimit } from '../src/utils/batch-lint';
+import type { BatchLintItem } from '../src/types';
+
+const makeItem = (overrides: Partial<BatchLintItem> = {}): BatchLintItem => ({
+  path: 'doc.md',
+  lintResult: [],
+  ...overrides,
+});
 
 const RULES_NO_EMPTY_LIST: LintMdRulesConfig = {
   'no-empty-list': 2,
@@ -175,6 +182,30 @@ describe('batchLint', () => {
       expect(result).toHaveLength(1);
       expect(result[0].fixedResult == null).toBe(true);
     });
+  });
+});
+
+describe('keepLintItem', () => {
+  test('keeps items with a non-empty lint report', () => {
+    expect(keepLintItem(makeItem({ lintResult: [{ message: 'x', name: 'y', content: 'z', severity: 2, loc: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } } }] }))).toBe(true);
+  });
+
+  test('drops items with empty lint report and null fixedResult', () => {
+    expect(keepLintItem(makeItem({ fixedResult: null }))).toBe(false);
+  });
+
+  test('drops items with empty lint report and empty notAppliedFixes', () => {
+    expect(keepLintItem(makeItem({ fixedResult: { result: 'x', notAppliedFixes: [] } }))).toBe(false);
+  });
+
+  test('keeps items with empty lint report but non-empty notAppliedFixes', () => {
+    expect(
+      keepLintItem(
+        makeItem({
+          fixedResult: { result: 'x', notAppliedFixes: [{ range: [0, 1], text: 'y' }] },
+        })
+      )
+    ).toBe(true);
   });
 });
 

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -86,6 +86,14 @@ export const resolveAdaptiveConcurrency = async (
   return Math.min(Math.max(limit, 1), mdFilePaths.length);
 };
 
+// Keep a file's result when it has lint findings, or — in fix mode — when
+// core left fixes unapplied due to conflicts. notAppliedFixes can in theory
+// occur without a lint report, so we must not drop it (see #86 / P1-6
+// "partially-unfixed is observable", which the #89 stderr warning surfaces).
+export const keepLintItem = (item: BatchLintItem): boolean =>
+  item.lintResult.length > 0
+  || Boolean(item.fixedResult?.notAppliedFixes?.length);
+
 export const batchLint = async (
   threadsCount: number,
   mdFilePaths: string[],
@@ -117,9 +125,7 @@ export const batchLint = async (
       concurrency
     );
 
-    return results.filter((item) => {
-      return item.lintResult.length > 0;
-    });
+    return results.filter(keepLintItem);
   }
   finally {
     await lintWorkerPool.destroy();


### PR DESCRIPTION
Closes #86.

## Summary
- `batchLint` no longer drops files whose `lintResult` is empty but whose `fixedResult.notAppliedFixes` is non-empty. The filter now retains an item when it has lint findings **or** leftover unapplied fixes.
- Extracted the condition into a pure, exported `keepLintItem` predicate so it is unit-testable without a real worker (same approach as `getUnappliedFixesWarnings` from #89).
- Complements the #89 stderr warning: `getUnappliedFixesWarnings` iterates the `batchLint` output, so keeping these items ensures the warning actually fires for them.

## Verification
- `npm run build` (tsc cjs + esm) passes.
- `npm test`: 10 suites / 100 tests pass (4 new `keepLintItem` unit tests).

🤖 Generated with [opencode](https://opencode.ai)