### PR TITLE
fix(get-report-data): use real fixable counts from core (A1)

### DIFF
--- a/__tests__/get-report-data.spec.ts
+++ b/__tests__/get-report-data.spec.ts
@@ -1,0 +1,107 @@
+import type { BatchLintItem } from '../src/types';
+import type { LintReportItem } from '@lint-md/core';
+import { getReportData } from '../src/utils/get-report-data';
+
+const makeReportItem = (
+  severity: number,
+  overrides: Partial<LintReportItem> = {}
+): LintReportItem => ({
+  name: 'rule-x',
+  message: 'some problem',
+  content: 'x',
+  severity,
+  loc: { start: { line: 1, column: 1 }, end: { line: 1, column: 2 } },
+  ...overrides,
+});
+
+const makeItem = (overrides: Partial<BatchLintItem> = {}): BatchLintItem => ({
+  path: 'doc.md',
+  lintResult: [],
+  ...overrides,
+});
+
+describe('getReportData', () => {
+  test('counts errors (severity 2) and warnings (severity 1) separately', () => {
+    const result = getReportData([
+      makeItem({
+        lintResult: [
+          makeReportItem(2),
+          makeReportItem(2),
+          makeReportItem(1),
+        ],
+        fixableErrorCount: 0,
+        fixableWarningCount: 0,
+      }),
+    ]);
+
+    expect(result.errorCount).toBe(2);
+    expect(result.warningCount).toBe(1);
+  });
+
+  test('aggregates error/warning counts across multiple files', () => {
+    const result = getReportData([
+      makeItem({
+        path: 'a.md',
+        lintResult: [makeReportItem(2), makeReportItem(1)],
+      }),
+      makeItem({
+        path: 'b.md',
+        lintResult: [makeReportItem(2), makeReportItem(2), makeReportItem(1)],
+      }),
+    ]);
+
+    expect(result.errorCount).toBe(3);
+    expect(result.warningCount).toBe(2);
+  });
+
+  test('shows the fixable summary when fixable counts are present', () => {
+    const { consoleMessage } = getReportData([
+      makeItem({
+        lintResult: [makeReportItem(2), makeReportItem(1)],
+        fixableErrorCount: 2,
+        fixableWarningCount: 1,
+      }),
+    ]);
+
+    expect(consoleMessage).toContain('2 errors and 1 warning potentially fixable with the `--fix` option.');
+  });
+
+  test('omits the fixable summary when fixable counts are zero', () => {
+    const { consoleMessage } = getReportData([
+      makeItem({
+        lintResult: [makeReportItem(2), makeReportItem(1)],
+        fixableErrorCount: 0,
+        fixableWarningCount: 0,
+      }),
+    ]);
+
+    expect(consoleMessage).not.toContain('potentially fixable with the `--fix` option.');
+  });
+
+  test('propagates real fixable counts through aggregation', () => {
+    const { consoleMessage } = getReportData([
+      makeItem({
+        lintResult: [makeReportItem(2)],
+        fixableErrorCount: 3,
+        fixableWarningCount: 0,
+      }),
+      makeItem({
+        lintResult: [makeReportItem(1)],
+        fixableErrorCount: 1,
+        fixableWarningCount: 4,
+      }),
+    ]);
+
+    expect(consoleMessage).toContain('4 errors and 4 warnings potentially fixable with the `--fix` option.');
+  });
+
+  test('drops files with no problems from the report', () => {
+    const { errorCount, warningCount, consoleMessage } = getReportData([
+      makeItem({ lintResult: [], fixableErrorCount: 0, fixableWarningCount: 0 }),
+    ]);
+
+    expect(errorCount).toBe(0);
+    expect(warningCount).toBe(0);
+    expect(consoleMessage).toBe('');
+  });
+});

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -103,7 +103,12 @@ program
       try {
         const result = lintMarkdown(content, rules, false);
         const { consoleMessage, errorCount, warningCount }
-          = getReportData([{ path: '(stdin)', lintResult: result.lintResult }]);
+          = getReportData([{
+            path: '(stdin)',
+            lintResult: result.lintResult,
+            fixableErrorCount: result.fixableErrorCount,
+            fixableWarningCount: result.fixableWarningCount,
+          }]);
 
         console.log(consoleMessage);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,4 +44,6 @@ export interface BatchLintItem {
   path: string
   lintResult: LintReportItem[]
   fixedResult?: FixedResult | null
+  fixableErrorCount?: number
+  fixableWarningCount?: number
 }

--- a/src/utils/get-report-data.ts
+++ b/src/utils/get-report-data.ts
@@ -44,8 +44,8 @@ export const getReportData = (problemResult: BatchLintItem[]) => {
       return {
         errorCount,
         filePath: path,
-        fixableErrorCount: 0,
-        fixableWarningCount: 0,
+        fixableErrorCount: res.fixableErrorCount ?? 0,
+        fixableWarningCount: res.fixableWarningCount ?? 0,
         messages: lintResult.map((lintItem) => {
           const { loc, message, severity, name } = lintItem;
           return {

--- a/src/utils/lint-worker.ts
+++ b/src/utils/lint-worker.ts
@@ -26,6 +26,8 @@ const lintWorker = async (options: LintWorkerOptions) => {
     path: filePath,
     lintResult: result.lintResult,
     fixedResult: result.fixedResult,
+    fixableErrorCount: result.fixableErrorCount,
+    fixableWarningCount: result.fixableWarningCount,
   };
 };
 


### PR DESCRIPTION


## Summary
- `get-report-data.ts` hardcoded per-file `fixableErrorCount` / `fixableWarningCount` to `0`, overwriting `@lint-md/core`'s real values, so the "potentially fixable with `--fix`" summary was always empty.
- Forward the real counts from `lintMarkdown`'s result through `lint-worker` into `BatchLintItem` (new optional `fixableErrorCount?` / `fixableWarningCount?` fields), and use them in `getReportData` (`res.fixableErrorCount ?? 0`). The existing aggregation/summary code was already correct — it was just fed zeros.
- Also populate the counts for the `--stdin` report path.

## Verification
- `npm run build` (tsc cjs + esm) passes.
- `npm test`: 11 suites / 106 tests pass (6 new `get-report-data` tests covering error/warning counting, multi-file aggregation, and fixable summary presence/absence).
