### PR TITLE
fix(package.json): pin js-yaml >=3.15.0 to resolve moderate vuln (#92)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,9 @@
     "tsx": "^4.22.4",
     "typescript": "^4.8.4"
   },
+  "overrides": {
+    "js-yaml": "^3.15.0"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/lint-md/cli/issues"


### PR DESCRIPTION
## 关联

Closes #92

## 问题

\`npm audit\` 在 devDependencies 传递链 \`@istanbuljs/load-nyc-config -> js-yaml@<3.15.0\` 检出 1 个 moderate 漏洞（GHSA-h67p-54hq-rp68，merge key 二次复杂度 DoS）。该依赖位于测试/覆盖率工具链，不进入生产 CLI。

## 修复

在 \`package.json\` 增加 npm \`overrides\` 将 \`js-yaml\` 固定到 \`^3.15.0\`：

- \`npm audit fix\` 已把磁盘上的解析版本从 \`3.14.2\` 升到 \`3.15.0\`；
- 选 \`overrides\` 而非仅依赖 lockfile：本仓库 \`package-lock.json\` 被 gitignore，lockfile 改动无法入库，override 写入受版本管理的 \`package.json\`，对全新 \`npm install\` 也持久生效；
- 未使用 \`npm audit fix --force\`，避免无审查的破坏性主版本升级。

## 验证

- \`npm audit\` → \`found 0 vulnerabilities\`
- \`npm test\` → 11 suites / 106 tests 全过
- \`npm run lint\` → 通过

## 提交拆分（单关注点）

- \`8b7a0bf\` \`chore(gitignore): ignore docs/ directory (local analysis only)\`（本会话早前决定的 docs 本地化）
- \`ab7a647\` \`fix(package.json): pin js-yaml >=3.15.0 to resolve moderate vulnerability (#92)\`