### PR TITLE
chore(prettier): add format script and explicit .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:cjs": "tsc -p tsconfig.json --target ESNext --module commonjs --outDir lib",
     "build:esm": "tsc -p tsconfig.json --target ESNext --module ESNext --outDir esm",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "format": "prettier --write \"src/**/*.ts\" \"__tests__/**/*.ts\"",
     "lint": "npm run typecheck && prettier --check \"src/**/*.ts\" \"__tests__/**/*.ts\"",
     "build": "rm -rf esm lib && run-p build:*",
     "clean": "rm -rf lib esm",


### PR DESCRIPTION
## 背景

PR1（#94）已用 `tsc --noEmit + prettier --check` 替换 eslint，但格式标准仍隐式依赖 prettier 默认配置，且没有供贡献者一键格式化的入口。本 PR 是分阶段方案的第二阶段：保留 prettier，把格式配置显式化并补上 `format` 脚本。

## 改动

- 新增 `.prettierrc`：显式锁定 prettier 2 默认选项（printWidth 80 / tabWidth 2 / semi / singleQuote false / trailingComma es5 / arrowParens always / endOfLine lf），与 PR1 已归一的代码一致
- `package.json` 新增 script：`format` = `prettier --write "src/**/*.ts" "__tests__/**/*.ts"`
- `lint` 脚本不变（仍 `typecheck && prettier --check`，CI 继续守护格式）
- `prettier` 依赖保留（`^2.7.1` → 2.8.8，不升 v3 以避免再次全量重格式化）

## 验证

- `prettier --check`（带新 `.prettierrc`）：All matched files use Prettier code style!
- `npm run format`：幂等，对受管文件无改动（git status 仅 `.prettierrc` + `package.json` 变化）
- `npm run lint`：通过（typecheck 0 错 + prettier --check 通过）
- `npm test`：11 suites / 106 tests 全过
- `npm run build`：成功

## 说明

- 不删除 `prettier`、不升级到 v3（避免全量重格式化）
- 不碰 jest / ts-jest 的 `glob` 弃用警告（测试链，非本次范围）
- 与 #93（B5 js-yaml）、#94（替换 eslint）均为独立 PR