### PR TITLE
fix: format core configuration errors

### DIFF
--- a/__tests__/core-config-error-cli.spec.ts
+++ b/__tests__/core-config-error-cli.spec.ts
@@ -9,13 +9,17 @@ const CLI = path.resolve(__dirname, "../src/lint-md.ts");
 describe("core rule configuration errors", () => {
   let tmpDir: string;
 
-  beforeEach(() => {
-    tmpDir = mkdtempSync(path.join(tmpdir(), "lint-md-invalid-rule-"));
+  const writeConfig = (rules: Record<string, unknown>) => {
     writeFileSync(
       path.join(tmpDir, ".lintmdrc"),
-      JSON.stringify({ rules: { "unknown-rule": 2 } }),
+      JSON.stringify({ rules }),
       "utf8"
     );
+  };
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), "lint-md-invalid-rule-"));
+    writeConfig({ "unknown-rule": 2 });
     writeFileSync(path.join(tmpDir, "fixture.md"), "# Title\n", "utf8");
   });
 
@@ -55,4 +59,30 @@ describe("core rule configuration errors", () => {
       expect(stderr).not.toContain("TypeError:");
     }
   );
+
+  test("formats a multiline unknown rule name without a stack", () => {
+    writeConfig({ "evil\n\r\u001B[31mred\u001B[0m\u001B]spoof\u0007name": 2 });
+
+    const { status, stderr } = runCli(["fixture.md"]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain('unknown rule "evil^J^Mredname"');
+    expect(stderr).not.toMatch(/^\s*at\s/m);
+    expect(stderr).not.toContain("TypeError:");
+  });
+
+  test("formats the duplicate-alias error thrown by core", () => {
+    writeConfig({
+      "alias-a": [{ meta: { name: "duplicate-name" } }, 2, {}],
+      "alias-b": [{ meta: { name: "duplicate-name" } }, 2, {}],
+    });
+
+    const { status, stderr } = runCli(["fixture.md"]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain('duplicate rule alias "duplicate-name"');
+    expect(stderr).toContain("your lint-md configuration file");
+    expect(stderr).not.toMatch(/^\s*at\s/m);
+    expect(stderr).not.toContain("TypeError:");
+  });
 });

--- a/__tests__/core-config-error-cli.spec.ts
+++ b/__tests__/core-config-error-cli.spec.ts
@@ -1,0 +1,58 @@
+import { execFileSync } from "child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import * as path from "path";
+
+const TSX = path.resolve(__dirname, "../node_modules/tsx/dist/cli.mjs");
+const CLI = path.resolve(__dirname, "../src/lint-md.ts");
+
+describe("core rule configuration errors", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), "lint-md-invalid-rule-"));
+    writeFileSync(
+      path.join(tmpDir, ".lintmdrc"),
+      JSON.stringify({ rules: { "unknown-rule": 2 } }),
+      "utf8"
+    );
+    writeFileSync(path.join(tmpDir, "fixture.md"), "# Title\n", "utf8");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const runCli = (args: string[], input?: string) => {
+    try {
+      execFileSync(process.execPath, [TSX, CLI, ...args], {
+        cwd: tmpDir,
+        encoding: "utf8",
+        input,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      throw new Error("CLI should exit with status 1");
+    } catch (error: any) {
+      return {
+        status: error.status,
+        stderr: error.stderr ?? "",
+      };
+    }
+  };
+
+  test.each([
+    ["stdin lint", ["--stdin"], "# Title\n"],
+    ["stdin fix", ["--stdin", "--fix"], "# Title\n"],
+    ["worker batch lint", ["fixture.md"], undefined],
+  ])(
+    "%s prints a configuration diagnostic without a stack",
+    (_, args, input) => {
+      const { status, stderr } = runCli(args as string[], input as string);
+
+      expect(status).toBe(1);
+      expect(stderr).toContain("[lint-md] Configuration error: unknown rule");
+      expect(stderr).not.toMatch(/^\s*at\s/m);
+      expect(stderr).not.toContain("TypeError:");
+    }
+  );
+});

--- a/__tests__/format-core-error.spec.ts
+++ b/__tests__/format-core-error.spec.ts
@@ -23,7 +23,22 @@ describe("formatCoreError", () => {
     expect(result).toEqual({
       handled: true,
       message:
-        '[lint-md] Configuration error: duplicate rule alias "custom-rule".\nCheck the "rules" section in .lintmdrc.',
+        '[lint-md] Configuration error: duplicate rule alias "custom-rule".\nCheck the "rules" section in your lint-md configuration file.',
+    });
+  });
+
+  test("formats and sanitizes a multiline unknown rule name", () => {
+    const ruleName = "evil\n\r\u001B[31mred\u001B[0m\u001B]spoof\u0007name";
+    const result = formatCoreError(
+      new TypeError(
+        `[lint-md] 未知规则 ${ruleName} 的配置格式非法，第三方规则必须使用 [rule, severity, options] 形式`
+      )
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      message:
+        '[lint-md] Configuration error: unknown rule "evil^J^Mredname" has an invalid configuration.\nThird-party rules must use [rule, severity, options].',
     });
   });
 

--- a/__tests__/format-core-error.spec.ts
+++ b/__tests__/format-core-error.spec.ts
@@ -1,0 +1,36 @@
+import { formatCoreError } from "../src/utils/format-core-error";
+
+describe("formatCoreError", () => {
+  test("formats the core unknown-rule configuration error", () => {
+    const result = formatCoreError(
+      new TypeError(
+        "[lint-md] 未知规则 custom-rule 的配置格式非法，第三方规则必须使用 [rule, severity, options] 形式"
+      )
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      message:
+        '[lint-md] Configuration error: unknown rule "custom-rule" has an invalid configuration.\nThird-party rules must use [rule, severity, options].',
+    });
+  });
+
+  test("formats the core duplicate-alias configuration error", () => {
+    const result = formatCoreError(
+      new TypeError("[lint-md] 规则别名冲突：custom-rule 已被另一规则占用")
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      message:
+        '[lint-md] Configuration error: duplicate rule alias "custom-rule".\nCheck the "rules" section in .lintmdrc.',
+    });
+  });
+
+  test("leaves unrelated errors unhandled", () => {
+    expect(formatCoreError(new TypeError("unrelated failure"))).toEqual({
+      handled: false,
+    });
+    expect(formatCoreError("unrelated failure")).toEqual({ handled: false });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "dependencies": {
-    "@lint-md/core": "^2.1.4",
+    "@lint-md/core": "^2.1.5",
     "chalk": "^4",
     "commander": "^9.4.1",
     "glob": "^13.0.6",

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -23,6 +23,7 @@ import { loadMdFiles } from "./utils/load-md-files";
 import { getReportData } from "./utils/get-report-data";
 import { filterFilesByMaxSize } from "./utils/filter-by-max-size";
 import { getUnappliedFixesWarnings } from "./utils/report-unapplied-fixes";
+import { formatCoreError } from "./utils/format-core-error";
 
 program
   .version(
@@ -94,7 +95,8 @@ program
           process.stdout.write(result.fixedResult?.result ?? content);
           return;
         } catch (e) {
-          console.error(e);
+          const formatted = formatCoreError(e);
+          console.error(formatted.handled ? formatted.message : e);
           process.exit(1);
         }
       }
@@ -121,7 +123,8 @@ program
           process.exit(1);
         }
       } catch (e) {
-        console.error(e);
+        const formatted = formatCoreError(e);
+        console.error(formatted.handled ? formatted.message : e);
         process.exit(1);
       }
 
@@ -200,7 +203,8 @@ program
         }
       }
     } catch (e) {
-      console.error(e);
+      const formatted = formatCoreError(e);
+      console.error(formatted.handled ? formatted.message : e);
       process.exit(1);
     }
 

--- a/src/utils/format-core-error.ts
+++ b/src/utils/format-core-error.ts
@@ -4,10 +4,23 @@ type FormattedCoreError =
   | { handled: true; message: string }
   | { handled: false };
 
-const UNKNOWN_RULE_PATTERN =
-  /^\[lint-md\] 未知规则 (.+) 的配置格式非法，第三方规则必须使用 \[rule, severity, options\] 形式$/u;
-const DUPLICATE_ALIAS_PATTERN =
-  /^\[lint-md\] 规则别名冲突：(.+) 已被另一规则占用$/u;
+const UNKNOWN_RULE_PREFIX = "[lint-md] 未知规则 ";
+const UNKNOWN_RULE_SUFFIX =
+  " 的配置格式非法，第三方规则必须使用 [rule, severity, options] 形式";
+const DUPLICATE_ALIAS_PREFIX = "[lint-md] 规则别名冲突：";
+const DUPLICATE_ALIAS_SUFFIX = " 已被另一规则占用";
+
+const extractBetween = (
+  message: string,
+  prefix: string,
+  suffix: string
+): string | null => {
+  if (!message.startsWith(prefix) || !message.endsWith(suffix)) {
+    return null;
+  }
+
+  return message.slice(prefix.length, message.length - suffix.length);
+};
 
 /**
  * Converts the known configuration errors introduced by @lint-md/core 2.1.5
@@ -19,9 +32,13 @@ export const formatCoreError = (error: unknown): FormattedCoreError => {
     return { handled: false };
   }
 
-  const unknownRule = error.message.match(UNKNOWN_RULE_PATTERN);
-  if (unknownRule) {
-    const ruleName = sanitizeTerminalText(unknownRule[1]);
+  const unknownRule = extractBetween(
+    error.message,
+    UNKNOWN_RULE_PREFIX,
+    UNKNOWN_RULE_SUFFIX
+  );
+  if (unknownRule !== null) {
+    const ruleName = sanitizeTerminalText(unknownRule);
     return {
       handled: true,
       message: [
@@ -31,14 +48,18 @@ export const formatCoreError = (error: unknown): FormattedCoreError => {
     };
   }
 
-  const duplicateAlias = error.message.match(DUPLICATE_ALIAS_PATTERN);
-  if (duplicateAlias) {
-    const alias = sanitizeTerminalText(duplicateAlias[1]);
+  const duplicateAlias = extractBetween(
+    error.message,
+    DUPLICATE_ALIAS_PREFIX,
+    DUPLICATE_ALIAS_SUFFIX
+  );
+  if (duplicateAlias !== null) {
+    const alias = sanitizeTerminalText(duplicateAlias);
     return {
       handled: true,
       message: [
         `[lint-md] Configuration error: duplicate rule alias "${alias}".`,
-        'Check the "rules" section in .lintmdrc.',
+        'Check the "rules" section in your lint-md configuration file.',
       ].join("\n"),
     };
   }

--- a/src/utils/format-core-error.ts
+++ b/src/utils/format-core-error.ts
@@ -1,0 +1,47 @@
+import { sanitizeTerminalText } from "./sanitize-terminal";
+
+type FormattedCoreError =
+  | { handled: true; message: string }
+  | { handled: false };
+
+const UNKNOWN_RULE_PATTERN =
+  /^\[lint-md\] 未知规则 (.+) 的配置格式非法，第三方规则必须使用 \[rule, severity, options\] 形式$/u;
+const DUPLICATE_ALIAS_PATTERN =
+  /^\[lint-md\] 规则别名冲突：(.+) 已被另一规则占用$/u;
+
+/**
+ * Converts the known configuration errors introduced by @lint-md/core 2.1.5
+ * into stable CLI diagnostics. Unknown errors deliberately remain unhandled
+ * so that programming and runtime failures retain their original details.
+ */
+export const formatCoreError = (error: unknown): FormattedCoreError => {
+  if (!(error instanceof Error)) {
+    return { handled: false };
+  }
+
+  const unknownRule = error.message.match(UNKNOWN_RULE_PATTERN);
+  if (unknownRule) {
+    const ruleName = sanitizeTerminalText(unknownRule[1]);
+    return {
+      handled: true,
+      message: [
+        `[lint-md] Configuration error: unknown rule "${ruleName}" has an invalid configuration.`,
+        "Third-party rules must use [rule, severity, options].",
+      ].join("\n"),
+    };
+  }
+
+  const duplicateAlias = error.message.match(DUPLICATE_ALIAS_PATTERN);
+  if (duplicateAlias) {
+    const alias = sanitizeTerminalText(duplicateAlias[1]);
+    return {
+      handled: true,
+      message: [
+        `[lint-md] Configuration error: duplicate rule alias "${alias}".`,
+        'Check the "rules" section in .lintmdrc.',
+      ].join("\n"),
+    };
+  }
+
+  return { handled: false };
+};


### PR DESCRIPTION
## Summary

- upgrade `@lint-md/core` to v2.1.5
- format known core rule-configuration errors into actionable CLI diagnostics
- cover stdin, `--stdin --fix`, and worker batch execution paths

## Validation

- `npm run build`
- `npm test`

Closes #97