### PR TITLE
feat: surface fix convergence warnings (#98)

### DIFF
--- a/__tests__/batch-lint.spec.ts
+++ b/__tests__/batch-lint.spec.ts
@@ -71,9 +71,9 @@ describe("batchLint", () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  test("returns empty array when no files are provided", async () => {
-    const result = await batchLint(2, [], false, false, RULES_NO_EMPTY_LIST);
-    expect(result).toEqual([]);
+  test("returns empty result when no files are provided", async () => {
+    const result = await batchLint(2, [], false, RULES_NO_EMPTY_LIST);
+    expect(result).toEqual({ allResults: [], actionableResults: [] });
   });
 
   describe("路径 payload", () => {
@@ -83,16 +83,18 @@ describe("batchLint", () => {
       await writeFile(fileA, TRIGGER_CONTENT, "utf8");
       await writeFile(fileB, TRIGGER_CONTENT, "utf8");
 
-      const result = await batchLint(
+      const { actionableResults } = await batchLint(
         2,
         [fileA, fileB],
-        false,
         false,
         RULES_NO_EMPTY_LIST
       );
 
-      expect(result.map((item) => item.path)).toEqual([fileA, fileB]);
-      result.forEach((item) => {
+      expect(actionableResults.map((item) => item.path)).toEqual([
+        fileA,
+        fileB,
+      ]);
+      actionableResults.forEach((item) => {
         expect(Array.isArray(item.lintResult)).toBe(true);
         expect(item.lintResult.length).toBeGreaterThan(0);
         expect(item.fixedResult == null).toBe(true);
@@ -103,17 +105,16 @@ describe("batchLint", () => {
       const file = path.join(tmpDir, "read-in-worker.md");
       await writeFile(file, TRIGGER_CONTENT, "utf8");
 
-      const result = await batchLint(
+      const { actionableResults } = await batchLint(
         1,
         [file],
-        false,
         false,
         RULES_NO_EMPTY_LIST
       );
 
-      expect(result).toHaveLength(1);
-      expect(result[0].path).toBe(file);
-      expect(result[0].lintResult[0].name).toBe("no-empty-list");
+      expect(actionableResults).toHaveLength(1);
+      expect(actionableResults[0].path).toBe(file);
+      expect(actionableResults[0].lintResult[0].name).toBe("no-empty-list");
     });
   });
 
@@ -127,31 +128,29 @@ describe("batchLint", () => {
         })
       );
 
-      const result = await batchLint(
+      const { actionableResults } = await batchLint(
         3,
         files,
-        false,
         false,
         RULES_NO_EMPTY_LIST
       );
 
-      expect(result).toHaveLength(fileCount);
-      expect(result.map((item) => item.path)).toEqual(files);
+      expect(actionableResults).toHaveLength(fileCount);
+      expect(actionableResults.map((item) => item.path)).toEqual(files);
     });
 
     test("threads greater than files does not error", async () => {
       const file = path.join(tmpDir, "single.md");
       await writeFile(file, TRIGGER_CONTENT, "utf8");
 
-      const result = await batchLint(
+      const { actionableResults } = await batchLint(
         16,
         [file],
-        false,
         false,
         RULES_NO_EMPTY_LIST
       );
 
-      expect(result).toHaveLength(1);
+      expect(actionableResults).toHaveLength(1);
     });
   });
 
@@ -164,15 +163,40 @@ describe("batchLint", () => {
       await writeFile(fileB, TRIGGER_CONTENT, "utf8");
       await writeFile(fileC, TRIGGER_CONTENT, "utf8");
 
-      const result = await batchLint(
+      const { actionableResults } = await batchLint(
         2,
         [fileA, fileB, fileC],
-        false,
         false,
         RULES_NO_EMPTY_LIST
       );
 
-      expect(result.map((item) => item.path)).toEqual([fileA, fileB, fileC]);
+      expect(actionableResults.map((item) => item.path)).toEqual([
+        fileA,
+        fileB,
+        fileC,
+      ]);
+    });
+  });
+
+  describe("allResults vs actionableResults", () => {
+    test("allResults keeps clean files; actionableResults drops them", async () => {
+      const cleanFile = path.join(tmpDir, "clean.md");
+      const dirtyFile = path.join(tmpDir, "dirty.md");
+      await writeFile(cleanFile, "# Clean content\n", "utf8");
+      await writeFile(dirtyFile, TRIGGER_CONTENT, "utf8");
+
+      const { allResults, actionableResults } = await batchLint(
+        1,
+        [cleanFile, dirtyFile],
+        false,
+        RULES_NO_EMPTY_LIST
+      );
+
+      expect(allResults.map((item) => item.path)).toEqual([
+        cleanFile,
+        dirtyFile,
+      ]);
+      expect(actionableResults.map((item) => item.path)).toEqual([dirtyFile]);
     });
   });
 
@@ -182,7 +206,7 @@ describe("batchLint", () => {
       await writeFile(file, "# Clean content\n", "utf8");
 
       await expect(
-        batchLint(2, [file], false, false, RULES_NO_EMPTY_LIST)
+        batchLint(2, [file], false, RULES_NO_EMPTY_LIST)
       ).resolves.toBeDefined();
     });
 
@@ -192,7 +216,7 @@ describe("batchLint", () => {
 
       try {
         await expect(
-          batchLint(1, [file], false, false, RULES_NO_EMPTY_LIST)
+          batchLint(1, [file], false, RULES_NO_EMPTY_LIST)
         ).rejects.toThrow();
         expect(destroySpy).toHaveBeenCalled();
       } finally {
@@ -206,33 +230,31 @@ describe("batchLint", () => {
       const file = path.join(tmpDir, "fixable.md");
       await writeFile(file, TRIGGER_CONTENT, "utf8");
 
-      const result = await batchLint(
+      const { actionableResults } = await batchLint(
         1,
         [file],
-        false,
         true,
         RULES_NO_EMPTY_LIST
       );
 
-      expect(result).toHaveLength(1);
-      expect(result[0].fixedResult).not.toBeNull();
-      expect(result[0].fixedResult?.result).toBeDefined();
+      expect(actionableResults).toHaveLength(1);
+      expect(actionableResults[0].fixedResult).not.toBeNull();
+      expect(actionableResults[0].fixedResult?.result).toBeDefined();
     });
 
     test("does not return fixedResult when fix mode is disabled", async () => {
       const file = path.join(tmpDir, "no-fix.md");
       await writeFile(file, TRIGGER_CONTENT, "utf8");
 
-      const result = await batchLint(
+      const { actionableResults } = await batchLint(
         1,
         [file],
-        false,
         false,
         RULES_NO_EMPTY_LIST
       );
 
-      expect(result).toHaveLength(1);
-      expect(result[0].fixedResult == null).toBe(true);
+      expect(actionableResults).toHaveLength(1);
+      expect(actionableResults[0].fixedResult == null).toBe(true);
     });
   });
 });
@@ -289,181 +311,65 @@ describe("getMaxFileSize", () => {
   let tmpDir: string;
 
   beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(tmpdir(), "batch-lint-max-"));
+    tmpDir = await mkdtemp(path.join(tmpdir(), "max-file-size-test-"));
   });
 
   afterEach(async () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  test("returns 0 for empty list", async () => {
+  test("returns 0 for empty input", async () => {
     expect(await getMaxFileSize([])).toBe(0);
   });
 
-  test("returns size of the only file", async () => {
-    const file = path.join(tmpDir, "only.md");
-    await writeFile(file, "hello");
-    expect(await getMaxFileSize([file])).toBe(5);
-  });
-
-  test("returns size of the largest file among many", async () => {
+  test("returns the largest file size in bytes", async () => {
     const small = path.join(tmpDir, "small.md");
     const large = path.join(tmpDir, "large.md");
-    const medium = path.join(tmpDir, "medium.md");
-    await writeFile(small, "a".repeat(10));
-    await writeFile(large, "b".repeat(1000));
-    await writeFile(medium, "c".repeat(500));
+    await writeFile(small, "a".repeat(10), "utf8");
+    await writeFile(large, "b".repeat(1024), "utf8");
 
-    expect(await getMaxFileSize([small, large, medium])).toBe(1000);
-  });
-
-  test("rejects when a file cannot be stat-ed", async () => {
-    const missing = path.join(tmpDir, "missing.md");
-    await expect(getMaxFileSize([missing])).rejects.toThrow();
-  });
-
-  test("bounds concurrent stat calls to STAT_CONCURRENCY_LIMIT", async () => {
-    const fileCount = STAT_CONCURRENCY_LIMIT * 3;
-    const filePaths = Array.from({ length: fileCount }, (_, index) =>
-      path.join(tmpDir, `bounded-${index}.md`)
-    );
-    const sizeMap = new Map(
-      filePaths.map((filePath, index) => [filePath, index + 1])
-    );
-
-    let inFlight = 0;
-    let maxInFlight = 0;
-
-    const fsPromises = require("fs/promises");
-    const statSpy = jest
-      .spyOn(fsPromises, "stat")
-      .mockImplementation((filePath: string) => {
-        inFlight++;
-        maxInFlight = Math.max(maxInFlight, inFlight);
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            inFlight--;
-            resolve({ size: sizeMap.get(filePath) ?? 0 });
-          }, 20);
-        });
-      });
-
-    try {
-      const result = await getMaxFileSize(filePaths);
-
-      expect(result).toBe(fileCount);
-      expect(statSpy).toHaveBeenCalledTimes(fileCount);
-      expect(maxInFlight).toBeGreaterThan(1);
-      expect(maxInFlight).toBeLessThanOrEqual(STAT_CONCURRENCY_LIMIT);
-    } finally {
-      statSpy.mockRestore();
-    }
+    expect(await getMaxFileSize([small, large])).toBe(1024);
   });
 });
 
 describe("resolveAdaptiveConcurrency", () => {
-  let tmpDir: string;
-
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(tmpdir(), "batch-lint-adaptive-"));
+  test("clamps to file count when below CPU count", async () => {
+    const files = ["a.md", "b.md"];
+    const result = await resolveAdaptiveConcurrency(
+      availableParallelism(),
+      files
+    );
+    expect(result).toBe(2);
   });
 
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true });
+  test("returns 0 when there are no files", async () => {
+    expect(await resolveAdaptiveConcurrency(4, [])).toBe(0);
   });
 
-  const writeSizedFile = async (name: string, sizeBytes: number) => {
-    const file = path.join(tmpDir, name);
-    await writeFile(file, Buffer.alloc(sizeBytes));
-    return file;
-  };
-
-  describe("numeric threadCount (preserves existing behavior)", () => {
-    test("numeric 2 with 3 files → 2", async () => {
-      const files = await Promise.all([
-        writeSizedFile("a.md", 100),
-        writeSizedFile("b.md", 100),
-        writeSizedFile("c.md", 100),
-      ]);
-      expect(await resolveAdaptiveConcurrency(2, files)).toBe(2);
-    });
-
-    test("numeric threads > fileCount is clamped to fileCount", async () => {
-      const file = await writeSizedFile("only.md", 100);
-      expect(await resolveAdaptiveConcurrency(100, [file])).toBe(1);
-    });
-
-    test("numeric 0 is clamped to 1 (matches existing min clamp)", async () => {
-      const files = await Promise.all([
-        writeSizedFile("a.md", 100),
-        writeSizedFile("b.md", 100),
-      ]);
-      expect(await resolveAdaptiveConcurrency(0, files)).toBe(1);
-    });
-
-    test("numeric threads ignores file size", async () => {
-      const files = await Promise.all(
-        Array.from({ length: 8 }, (_, index) =>
-          writeSizedFile(`huge-${index}.md`, 10 * 1024 * 1024)
-        )
-      );
-
-      expect(await resolveAdaptiveConcurrency(8, files)).toBe(8);
-    });
+  test("respects a numeric threadCount", async () => {
+    expect(await resolveAdaptiveConcurrency(1, ["a.md", "b.md", "c.md"])).toBe(
+      1
+    );
+    expect(await resolveAdaptiveConcurrency(5, ["a.md", "b.md"])).toBe(2);
   });
 
-  describe("auto threadCount", () => {
-    test("empty file list → 0", async () => {
-      expect(await resolveAdaptiveConcurrency("auto", [])).toBe(0);
-    });
+  test("clamps large file paths to a single thread", async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), "adaptive-"));
+    try {
+      const huge = path.join(tmp, "huge.md");
+      await writeFile(huge, "x".repeat(6 * 1024 * 1024), "utf8");
 
-    test("small files (< 1 MiB) use cpuLimit clamped to fileCount", async () => {
-      const files = await Promise.all([
-        writeSizedFile("a.md", 1024),
-        writeSizedFile("b.md", 2048),
-        writeSizedFile("c.md", 4096),
-      ]);
-      const cpuLimit = availableParallelism();
-      expect(await resolveAdaptiveConcurrency("auto", files)).toBe(
-        Math.min(cpuLimit, files.length)
-      );
-    });
+      const result = await resolveAdaptiveConcurrency("auto", [huge]);
+      expect(result).toBe(1);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+});
 
-    test("max file exactly 1 MiB caps at 2", async () => {
-      const files = await Promise.all([
-        writeSizedFile("small.md", 1024),
-        writeSizedFile("one-mib.md", 1024 * 1024),
-      ]);
-      expect(
-        await resolveAdaptiveConcurrency("auto", files)
-      ).toBeLessThanOrEqual(2);
-    });
-
-    test("max file 1.5 MiB caps at 2", async () => {
-      const file = await writeSizedFile("medium.md", 1.5 * 1024 * 1024);
-      expect(
-        await resolveAdaptiveConcurrency("auto", [file])
-      ).toBeLessThanOrEqual(2);
-    });
-
-    test("max file exactly 5 MiB forces 1", async () => {
-      const file = await writeSizedFile("five-mib.md", 5 * 1024 * 1024);
-      expect(await resolveAdaptiveConcurrency("auto", [file])).toBe(1);
-    });
-
-    test("max file 6 MiB forces 1", async () => {
-      const file = await writeSizedFile("six-mib.md", 6 * 1024 * 1024);
-      expect(await resolveAdaptiveConcurrency("auto", [file])).toBe(1);
-    });
-
-    test("single small file → 1", async () => {
-      const file = await writeSizedFile("only.md", 100);
-      expect(await resolveAdaptiveConcurrency("auto", [file])).toBe(1);
-    });
-
-    test("medium cap respects fileCount when files < 2", async () => {
-      const file = await writeSizedFile("one-mib.md", 1.2 * 1024 * 1024);
-      expect(await resolveAdaptiveConcurrency("auto", [file])).toBe(1);
-    });
+describe("STAT_CONCURRENCY_LIMIT", () => {
+  test("is a positive integer", () => {
+    expect(STAT_CONCURRENCY_LIMIT).toBeGreaterThan(0);
+    expect(Number.isInteger(STAT_CONCURRENCY_LIMIT)).toBe(true);
   });
 });

--- a/__tests__/batch-lint.spec.ts
+++ b/__tests__/batch-lint.spec.ts
@@ -178,28 +178,6 @@ describe("batchLint", () => {
     });
   });
 
-  describe("allResults vs actionableResults", () => {
-    test("allResults keeps clean files; actionableResults drops them", async () => {
-      const cleanFile = path.join(tmpDir, "clean.md");
-      const dirtyFile = path.join(tmpDir, "dirty.md");
-      await writeFile(cleanFile, "# Clean content\n", "utf8");
-      await writeFile(dirtyFile, TRIGGER_CONTENT, "utf8");
-
-      const { allResults, actionableResults } = await batchLint(
-        1,
-        [cleanFile, dirtyFile],
-        false,
-        RULES_NO_EMPTY_LIST
-      );
-
-      expect(allResults.map((item) => item.path)).toEqual([
-        cleanFile,
-        dirtyFile,
-      ]);
-      expect(actionableResults.map((item) => item.path)).toEqual([dirtyFile]);
-    });
-  });
-
   describe("pool 销毁", () => {
     test("returns successfully and does not leave worker processes hanging", async () => {
       const file = path.join(tmpDir, "pool-cleanup.md");
@@ -311,65 +289,181 @@ describe("getMaxFileSize", () => {
   let tmpDir: string;
 
   beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(tmpdir(), "max-file-size-test-"));
+    tmpDir = await mkdtemp(path.join(tmpdir(), "batch-lint-max-"));
   });
 
   afterEach(async () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  test("returns 0 for empty input", async () => {
+  test("returns 0 for empty list", async () => {
     expect(await getMaxFileSize([])).toBe(0);
   });
 
-  test("returns the largest file size in bytes", async () => {
+  test("returns size of the only file", async () => {
+    const file = path.join(tmpDir, "only.md");
+    await writeFile(file, "hello");
+    expect(await getMaxFileSize([file])).toBe(5);
+  });
+
+  test("returns size of the largest file among many", async () => {
     const small = path.join(tmpDir, "small.md");
     const large = path.join(tmpDir, "large.md");
-    await writeFile(small, "a".repeat(10), "utf8");
-    await writeFile(large, "b".repeat(1024), "utf8");
+    const medium = path.join(tmpDir, "medium.md");
+    await writeFile(small, "a".repeat(10));
+    await writeFile(large, "b".repeat(1000));
+    await writeFile(medium, "c".repeat(500));
 
-    expect(await getMaxFileSize([small, large])).toBe(1024);
+    expect(await getMaxFileSize([small, large, medium])).toBe(1000);
   });
-});
 
-describe("resolveAdaptiveConcurrency", () => {
-  test("clamps to file count when below CPU count", async () => {
-    const files = ["a.md", "b.md"];
-    const result = await resolveAdaptiveConcurrency(
-      availableParallelism(),
-      files
+  test("rejects when a file cannot be stat-ed", async () => {
+    const missing = path.join(tmpDir, "missing.md");
+    await expect(getMaxFileSize([missing])).rejects.toThrow();
+  });
+
+  test("bounds concurrent stat calls to STAT_CONCURRENCY_LIMIT", async () => {
+    const fileCount = STAT_CONCURRENCY_LIMIT * 3;
+    const filePaths = Array.from({ length: fileCount }, (_, index) =>
+      path.join(tmpDir, `bounded-${index}.md`)
     );
-    expect(result).toBe(2);
-  });
-
-  test("returns 0 when there are no files", async () => {
-    expect(await resolveAdaptiveConcurrency(4, [])).toBe(0);
-  });
-
-  test("respects a numeric threadCount", async () => {
-    expect(await resolveAdaptiveConcurrency(1, ["a.md", "b.md", "c.md"])).toBe(
-      1
+    const sizeMap = new Map(
+      filePaths.map((filePath, index) => [filePath, index + 1])
     );
-    expect(await resolveAdaptiveConcurrency(5, ["a.md", "b.md"])).toBe(2);
-  });
 
-  test("clamps large file paths to a single thread", async () => {
-    const tmp = await mkdtemp(path.join(tmpdir(), "adaptive-"));
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const fsPromises = require("fs/promises");
+    const statSpy = jest
+      .spyOn(fsPromises, "stat")
+      .mockImplementation((filePath: string) => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            inFlight--;
+            resolve({ size: sizeMap.get(filePath) ?? 0 });
+          }, 20);
+        });
+      });
+
     try {
-      const huge = path.join(tmp, "huge.md");
-      await writeFile(huge, "x".repeat(6 * 1024 * 1024), "utf8");
+      const result = await getMaxFileSize(filePaths);
 
-      const result = await resolveAdaptiveConcurrency("auto", [huge]);
-      expect(result).toBe(1);
+      expect(result).toBe(fileCount);
+      expect(statSpy).toHaveBeenCalledTimes(fileCount);
+      expect(maxInFlight).toBeGreaterThan(1);
+      expect(maxInFlight).toBeLessThanOrEqual(STAT_CONCURRENCY_LIMIT);
     } finally {
-      await rm(tmp, { recursive: true, force: true });
+      statSpy.mockRestore();
     }
   });
 });
 
-describe("STAT_CONCURRENCY_LIMIT", () => {
-  test("is a positive integer", () => {
-    expect(STAT_CONCURRENCY_LIMIT).toBeGreaterThan(0);
-    expect(Number.isInteger(STAT_CONCURRENCY_LIMIT)).toBe(true);
+describe("resolveAdaptiveConcurrency", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "batch-lint-adaptive-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  const writeSizedFile = async (name: string, sizeBytes: number) => {
+    const file = path.join(tmpDir, name);
+    await writeFile(file, Buffer.alloc(sizeBytes));
+    return file;
+  };
+
+  describe("numeric threadCount (preserves existing behavior)", () => {
+    test("numeric 2 with 3 files → 2", async () => {
+      const files = await Promise.all([
+        writeSizedFile("a.md", 100),
+        writeSizedFile("b.md", 100),
+        writeSizedFile("c.md", 100),
+      ]);
+      expect(await resolveAdaptiveConcurrency(2, files)).toBe(2);
+    });
+
+    test("numeric threads > fileCount is clamped to fileCount", async () => {
+      const file = await writeSizedFile("only.md", 100);
+      expect(await resolveAdaptiveConcurrency(100, [file])).toBe(1);
+    });
+
+    test("numeric 0 is clamped to 1 (matches existing min clamp)", async () => {
+      const files = await Promise.all([
+        writeSizedFile("a.md", 100),
+        writeSizedFile("b.md", 100),
+      ]);
+      expect(await resolveAdaptiveConcurrency(0, files)).toBe(1);
+    });
+
+    test("numeric threads ignores file size", async () => {
+      const files = await Promise.all(
+        Array.from({ length: 8 }, (_, index) =>
+          writeSizedFile(`huge-${index}.md`, 10 * 1024 * 1024)
+        )
+      );
+
+      expect(await resolveAdaptiveConcurrency(8, files)).toBe(8);
+    });
+  });
+
+  describe("auto threadCount", () => {
+    test("empty file list → 0", async () => {
+      expect(await resolveAdaptiveConcurrency("auto", [])).toBe(0);
+    });
+
+    test("small files (< 1 MiB) use cpuLimit clamped to fileCount", async () => {
+      const files = await Promise.all([
+        writeSizedFile("a.md", 1024),
+        writeSizedFile("b.md", 2048),
+        writeSizedFile("c.md", 4096),
+      ]);
+      const cpuLimit = availableParallelism();
+      expect(await resolveAdaptiveConcurrency("auto", files)).toBe(
+        Math.min(cpuLimit, files.length)
+      );
+    });
+
+    test("max file exactly 1 MiB caps at 2", async () => {
+      const files = await Promise.all([
+        writeSizedFile("small.md", 1024),
+        writeSizedFile("one-mib.md", 1024 * 1024),
+      ]);
+      expect(
+        await resolveAdaptiveConcurrency("auto", files)
+      ).toBeLessThanOrEqual(2);
+    });
+
+    test("max file 1.5 MiB caps at 2", async () => {
+      const file = await writeSizedFile("medium.md", 1.5 * 1024 * 1024);
+      expect(
+        await resolveAdaptiveConcurrency("auto", [file])
+      ).toBeLessThanOrEqual(2);
+    });
+
+    test("max file exactly 5 MiB forces 1", async () => {
+      const file = await writeSizedFile("five-mib.md", 5 * 1024 * 1024);
+      expect(await resolveAdaptiveConcurrency("auto", [file])).toBe(1);
+    });
+
+    test("max file 6 MiB forces 1", async () => {
+      const file = await writeSizedFile("six-mib.md", 6 * 1024 * 1024);
+      expect(await resolveAdaptiveConcurrency("auto", [file])).toBe(1);
+    });
+
+    test("single small file → 1", async () => {
+      const file = await writeSizedFile("only.md", 100);
+      expect(await resolveAdaptiveConcurrency("auto", [file])).toBe(1);
+    });
+
+    test("medium cap respects fileCount when files < 2", async () => {
+      const file = await writeSizedFile("one-mib.md", 1.2 * 1024 * 1024);
+      expect(await resolveAdaptiveConcurrency("auto", [file])).toBe(1);
+    });
   });
 });

--- a/__tests__/keep-lint-item.spec.ts
+++ b/__tests__/keep-lint-item.spec.ts
@@ -77,8 +77,12 @@ describe("keepLintItem", () => {
     );
   });
 
-  test("drops items with no fixedResult and no lint findings", () => {
-    expect(keepLintItem(baseItem({}))).toBe(false);
+  test("drops items with fixedResult: null", () => {
+    expect(keepLintItem(baseItem({ fixedResult: null }))).toBe(false);
+  });
+
+  test("drops items with fixedResult: undefined", () => {
+    expect(keepLintItem(baseItem({ fixedResult: undefined }))).toBe(false);
   });
 
   test("treats pre-#182 cores (no convergence field) like the old behaviour", () => {

--- a/__tests__/keep-lint-item.spec.ts
+++ b/__tests__/keep-lint-item.spec.ts
@@ -1,0 +1,87 @@
+import { keepLintItem } from "../src/utils/batch-lint";
+import { FixConvergence } from "@lint-md/core";
+import type { FixedResult } from "@lint-md/core";
+import type { BatchLintItem } from "../src/types";
+
+const baseItem = (
+  overrides: Partial<BatchLintItem> & {
+    convergence?: FixConvergence;
+  }
+): BatchLintItem => {
+  const { convergence, ...rest } = overrides;
+  const fixedResult: FixedResult = {
+    result: "",
+    notAppliedFixes: [],
+  };
+  if (convergence !== undefined) {
+    fixedResult.convergence = convergence;
+  }
+  return {
+    path: "a.md",
+    lintResult: [],
+    fixedResult,
+    ...rest,
+  };
+};
+
+describe("keepLintItem", () => {
+  test("keeps items with lint findings", () => {
+    expect(
+      keepLintItem(
+        baseItem({
+          lintResult: [
+            {
+              loc: {
+                start: { line: 1, column: 1 },
+                end: { line: 1, column: 2 },
+              },
+              message: "x",
+              name: "r",
+              content: "x",
+              severity: 2 as any,
+            },
+          ],
+        })
+      )
+    ).toBe(true);
+  });
+
+  test("keeps items with unapplied fixes", () => {
+    expect(
+      keepLintItem(
+        baseItem({
+          fixedResult: {
+            result: "",
+            notAppliedFixes: [{ range: [0, 1], text: "x" }],
+          },
+        })
+      )
+    ).toBe(true);
+  });
+
+  test("keeps items with cycle convergence so #98 warning has a target", () => {
+    expect(
+      keepLintItem(baseItem({ convergence: FixConvergence.CYCLE_DETECTED }))
+    ).toBe(true);
+  });
+
+  test("keeps items with max convergence so #98 warning has a target", () => {
+    expect(
+      keepLintItem(baseItem({ convergence: FixConvergence.MAX_ROUNDS }))
+    ).toBe(true);
+  });
+
+  test("drops items with stable convergence and no other signal", () => {
+    expect(keepLintItem(baseItem({ convergence: FixConvergence.STABLE }))).toBe(
+      false
+    );
+  });
+
+  test("drops items with no fixedResult and no lint findings", () => {
+    expect(keepLintItem(baseItem({}))).toBe(false);
+  });
+
+  test("treats pre-#182 cores (no convergence field) like the old behaviour", () => {
+    expect(keepLintItem(baseItem({}))).toBe(false);
+  });
+});

--- a/__tests__/report-incomplete-fixes.spec.ts
+++ b/__tests__/report-incomplete-fixes.spec.ts
@@ -1,0 +1,154 @@
+import {
+  getFixDevMetrics,
+  getIncompleteFixWarnings,
+  isIncompleteFix,
+} from "../src/utils/report-incomplete-fixes";
+import { FixConvergence } from "@lint-md/core";
+import type { FixedResult } from "@lint-md/core";
+import type { BatchLintItem } from "../src/types";
+
+const makeItem = (
+  overrides: Partial<BatchLintItem> & {
+    convergence?: FixConvergence;
+    metrics?: FixedResult["metrics"];
+  }
+): BatchLintItem => {
+  const { convergence, metrics, ...rest } = overrides;
+  const fixedResult: FixedResult = {
+    result: "",
+    notAppliedFixes: [],
+  };
+  if (convergence !== undefined) {
+    fixedResult.convergence = convergence;
+  }
+  if (metrics) {
+    fixedResult.metrics = metrics;
+  }
+  return {
+    path: "docs/example.md",
+    lintResult: [],
+    fixedResult,
+    ...rest,
+  };
+};
+
+describe("report-incomplete-fixes", () => {
+  describe("isIncompleteFix", () => {
+    test("returns true for cycle convergence", () => {
+      expect(
+        isIncompleteFix(
+          makeItem({ convergence: FixConvergence.CYCLE_DETECTED })
+        )
+      ).toBe(true);
+    });
+
+    test("returns true for max convergence", () => {
+      expect(
+        isIncompleteFix(makeItem({ convergence: FixConvergence.MAX_ROUNDS }))
+      ).toBe(true);
+    });
+
+    test("returns false for stable convergence", () => {
+      expect(
+        isIncompleteFix(makeItem({ convergence: FixConvergence.STABLE }))
+      ).toBe(false);
+    });
+
+    test("returns false when convergence is undefined (pre-#182 cores)", () => {
+      expect(isIncompleteFix(makeItem({}))).toBe(false);
+    });
+
+    test("returns false when fixedResult is null", () => {
+      expect(isIncompleteFix(makeItem({ fixedResult: null }))).toBe(false);
+    });
+  });
+
+  describe("getIncompleteFixWarnings", () => {
+    test("emits one warning per incomplete item, in input order", () => {
+      const items: BatchLintItem[] = [
+        makeItem({ path: "a.md", convergence: FixConvergence.STABLE }),
+        makeItem({ path: "b.md", convergence: FixConvergence.CYCLE_DETECTED }),
+        makeItem({ path: "c.md", convergence: FixConvergence.MAX_ROUNDS }),
+        makeItem({ path: "d.md", convergence: FixConvergence.STABLE }),
+        makeItem({ path: "e.md", convergence: FixConvergence.CYCLE_DETECTED }),
+      ];
+
+      expect(getIncompleteFixWarnings(items)).toEqual([
+        "[lint-md] Fix did not fully converge for b.md: cycle.",
+        "[lint-md] Fix did not fully converge for c.md: max.",
+        "[lint-md] Fix did not fully converge for e.md: cycle.",
+      ]);
+    });
+
+    test("skips items without a fixedResult", () => {
+      const items: BatchLintItem[] = [
+        makeItem({ path: "lint-only.md", fixedResult: null }),
+        makeItem({
+          path: "broken.md",
+          convergence: FixConvergence.CYCLE_DETECTED,
+        }),
+      ];
+
+      expect(getIncompleteFixWarnings(items)).toEqual([
+        "[lint-md] Fix did not fully converge for broken.md: cycle.",
+      ]);
+    });
+
+    test("sanitizes the file path", () => {
+      const items: BatchLintItem[] = [
+        makeItem({
+          path: "evil\n::error::spoof.md",
+          convergence: FixConvergence.MAX_ROUNDS,
+        }),
+      ];
+
+      const [warning] = getIncompleteFixWarnings(items);
+      expect(warning).not.toContain("\n::error::");
+      expect(warning).toContain("evil");
+    });
+
+    test("returns no warnings for a clean fix run", () => {
+      const items: BatchLintItem[] = [
+        makeItem({ path: "ok.md", convergence: FixConvergence.STABLE }),
+        makeItem({ path: "old.md" }),
+      ];
+
+      expect(getIncompleteFixWarnings(items)).toEqual([]);
+    });
+  });
+
+  describe("getFixDevMetrics", () => {
+    test("emits one line per item that has metrics", () => {
+      const items: BatchLintItem[] = [
+        makeItem({
+          path: "a.md",
+          convergence: FixConvergence.STABLE,
+          metrics: { rounds: 1, wallTime: 0.5, perRound: [0.5] },
+        }),
+        makeItem({ path: "b.md", convergence: FixConvergence.CYCLE_DETECTED }),
+        makeItem({
+          path: "c.md",
+          convergence: FixConvergence.MAX_ROUNDS,
+          metrics: { rounds: 10, wallTime: 3.14159, perRound: [0.1, 0.2] },
+        }),
+      ];
+
+      expect(getFixDevMetrics(items)).toEqual([
+        "[lint-md] Fix metrics: a.md: convergence=stable, rounds=1, wallTime=0.50ms",
+        "[lint-md] Fix metrics: c.md: convergence=max, rounds=10, wallTime=3.14ms",
+      ]);
+    });
+
+    test("returns no lines when no item exposes metrics", () => {
+      expect(
+        getFixDevMetrics([
+          makeItem({ path: "a.md", convergence: FixConvergence.STABLE }),
+          makeItem({
+            path: "b.md",
+            convergence: FixConvergence.CYCLE_DETECTED,
+          }),
+        ])
+      ).toEqual([]);
+    });
+  });
+});

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -97,16 +97,20 @@ program
         try {
           const result = lintMarkdown(content, rules, true);
           process.stdout.write(result.fixedResult?.result ?? content);
-          for (const warning of getIncompleteFixWarnings([
-            {
-              path: "(stdin)",
-              lintResult: result.lintResult,
-              fixedResult: result.fixedResult,
-              fixableErrorCount: result.fixableErrorCount,
-              fixableWarningCount: result.fixableWarningCount,
-            },
-          ])) {
+          const stdinItem = {
+            path: "(stdin)",
+            lintResult: result.lintResult,
+            fixedResult: result.fixedResult,
+            fixableErrorCount: result.fixableErrorCount,
+            fixableWarningCount: result.fixableWarningCount,
+          };
+          for (const warning of getIncompleteFixWarnings([stdinItem])) {
             console.error(warning);
+          }
+          if (isDev) {
+            for (const line of getFixDevMetrics([stdinItem])) {
+              console.error(line);
+            }
           }
           return;
         } catch (e) {
@@ -184,17 +188,16 @@ program
     }
 
     try {
-      const lintResult = await batchLint(
+      const { allResults, actionableResults } = await batchLint(
         effectiveThreads,
         mdFiles,
-        isDev,
         isFixMode,
         rules
       );
 
       if (!isFixMode) {
         const { consoleMessage, errorCount, warningCount } =
-          getReportData(lintResult);
+          getReportData(actionableResults);
 
         console.log(consoleMessage);
 
@@ -203,7 +206,7 @@ program
         }
       } else {
         await runTasksWithLimit(
-          lintResult
+          actionableResults
             .filter(({ fixedResult }) => fixedResult)
             .map(
               ({ path, fixedResult }) =>
@@ -213,15 +216,15 @@ program
           effectiveThreads
         );
 
-        for (const warning of getIncompleteFixWarnings(lintResult)) {
+        for (const warning of getIncompleteFixWarnings(actionableResults)) {
           console.error(warning);
         }
-        for (const warning of getUnappliedFixesWarnings(lintResult)) {
+        for (const warning of getUnappliedFixesWarnings(actionableResults)) {
           console.error(warning);
         }
 
         if (isDev) {
-          for (const line of getFixDevMetrics(lintResult)) {
+          for (const line of getFixDevMetrics(allResults)) {
             console.log(line);
           }
         }

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -23,6 +23,10 @@ import { loadMdFiles } from "./utils/load-md-files";
 import { getReportData } from "./utils/get-report-data";
 import { filterFilesByMaxSize } from "./utils/filter-by-max-size";
 import { getUnappliedFixesWarnings } from "./utils/report-unapplied-fixes";
+import {
+  getFixDevMetrics,
+  getIncompleteFixWarnings,
+} from "./utils/report-incomplete-fixes";
 import { formatCoreError } from "./utils/format-core-error";
 
 program
@@ -93,6 +97,17 @@ program
         try {
           const result = lintMarkdown(content, rules, true);
           process.stdout.write(result.fixedResult?.result ?? content);
+          for (const warning of getIncompleteFixWarnings([
+            {
+              path: "(stdin)",
+              lintResult: result.lintResult,
+              fixedResult: result.fixedResult,
+              fixableErrorCount: result.fixableErrorCount,
+              fixableWarningCount: result.fixableWarningCount,
+            },
+          ])) {
+            console.error(warning);
+          }
           return;
         } catch (e) {
           const formatted = formatCoreError(e);
@@ -198,8 +213,17 @@ program
           effectiveThreads
         );
 
+        for (const warning of getIncompleteFixWarnings(lintResult)) {
+          console.error(warning);
+        }
         for (const warning of getUnappliedFixesWarnings(lintResult)) {
           console.error(warning);
+        }
+
+        if (isDev) {
+          for (const line of getFixDevMetrics(lintResult)) {
+            console.log(line);
+          }
         }
       }
     } catch (e) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,6 @@ export interface LintWorkerOptions {
   filePath: string;
   rules?: LintMdRulesConfig;
   isFixMode?: boolean;
-  isDev?: boolean;
 }
 
 /** batchLint 单个文件的 lint 结果 */

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -103,15 +103,21 @@ export const keepLintItem = (item: BatchLintItem): boolean =>
   Boolean(item.fixedResult?.notAppliedFixes?.length) ||
   isIncompleteFix(item);
 
+export interface BatchLintResult {
+  /** Every worker result, including clean files. Used for dev metrics. */
+  allResults: BatchLintItem[];
+  /** Worker results filtered through `keepLintItem`. Used for I/O, warnings, and reporting. */
+  actionableResults: BatchLintItem[];
+}
+
 export const batchLint = async (
   threadsCount: number,
   mdFilePaths: string[],
-  isDev: boolean,
   isFixMode: boolean,
   rules: LintMdRulesConfig
-): Promise<BatchLintItem[]> => {
+): Promise<BatchLintResult> => {
   if (mdFilePaths.length === 0) {
-    return [];
+    return { allResults: [], actionableResults: [] };
   }
 
   const concurrency = Math.min(Math.max(threadsCount, 1), mdFilePaths.length);
@@ -122,20 +128,22 @@ export const batchLint = async (
   });
 
   try {
-    const results = await runTasksWithLimit<BatchLintItem>(
+    const allResults = await runTasksWithLimit<BatchLintItem>(
       mdFilePaths.map((filePath) => {
         return () =>
           lintWorkerPool.run({
             filePath,
             isFixMode,
             rules,
-            isDev,
           } as LintWorkerOptions);
       }),
       concurrency
     );
 
-    return results.filter(keepLintItem);
+    return {
+      allResults,
+      actionableResults: allResults.filter(keepLintItem),
+    };
   } finally {
     await lintWorkerPool.destroy();
   }

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -5,6 +5,7 @@ import { availableParallelism } from "os";
 import { Piscina } from "piscina";
 import type { LintMdRulesConfig } from "@lint-md/core";
 import type { BatchLintItem, LintWorkerOptions, ThreadCount } from "../types";
+import { isIncompleteFix } from "./report-incomplete-fixes";
 
 const ONE_MIB = 1024 * 1024;
 const FIVE_MIB = 5 * ONE_MIB;
@@ -93,9 +94,14 @@ export const resolveAdaptiveConcurrency = async (
 // core left fixes unapplied due to conflicts. notAppliedFixes can in theory
 // occur without a lint report, so we must not drop it (see #86 / P1-6
 // "partially-unfixed is observable", which the #89 stderr warning surfaces).
+// Also retain items whose fix pass did not fully converge (cycle / max) so
+// the #98 stderr warning has a target. Older cores that predate the
+// `convergence` field leave it undefined, which is treated as stable and
+// filtered as before.
 export const keepLintItem = (item: BatchLintItem): boolean =>
   item.lintResult.length > 0 ||
-  Boolean(item.fixedResult?.notAppliedFixes?.length);
+  Boolean(item.fixedResult?.notAppliedFixes?.length) ||
+  isIncompleteFix(item);
 
 export const batchLint = async (
   threadsCount: number,

--- a/src/utils/lint-worker.ts
+++ b/src/utils/lint-worker.ts
@@ -3,24 +3,10 @@ import { lintMarkdown } from "@lint-md/core";
 import type { LintWorkerOptions } from "../types";
 
 const lintWorker = async (options: LintWorkerOptions) => {
-  const { filePath, rules, isFixMode, isDev } = options;
-  const start = new Date().getTime();
+  const { filePath, rules, isFixMode } = options;
 
   const content = await readFile(filePath, "utf8");
   const result = lintMarkdown(content, rules, isFixMode);
-
-  const end = new Date().getTime();
-
-  if (isDev) {
-    console.log(
-      "File 耗时：",
-      end - start,
-      " 文件：",
-      filePath,
-      " 字符串长度：",
-      content.length
-    );
-  }
 
   return {
     path: filePath,

--- a/src/utils/report-incomplete-fixes.ts
+++ b/src/utils/report-incomplete-fixes.ts
@@ -1,0 +1,58 @@
+import type { BatchLintItem } from "../types";
+import { FixConvergence } from "@lint-md/core";
+import { sanitizeTerminalText } from "./sanitize-terminal";
+
+// @lint-md/core 2.1.5 (see core #182) exposes an optional
+// `convergence: "stable" | "cycle" | "max"` on FixedResult. CLI treats
+// `cycle` (oscillation) and `max` (MAX_ROUNDS truncation) as quality
+// warnings, never hard errors — the fix pass still produced output.
+const INCOMPLETE_CONVERGENCE: ReadonlySet<FixConvergence> = new Set([
+  FixConvergence.CYCLE_DETECTED,
+  FixConvergence.MAX_ROUNDS,
+]);
+
+export const isIncompleteFix = (item: BatchLintItem): boolean => {
+  const convergence = item.fixedResult?.convergence;
+  return convergence !== undefined && INCOMPLETE_CONVERGENCE.has(convergence);
+};
+
+export const getIncompleteFixWarnings = (
+  lintResult: BatchLintItem[]
+): string[] => {
+  const warnings: string[] = [];
+
+  for (const item of lintResult) {
+    const convergence = item.fixedResult?.convergence;
+    if (convergence !== undefined && INCOMPLETE_CONVERGENCE.has(convergence)) {
+      warnings.push(
+        `[lint-md] Fix did not fully converge for ${sanitizeTerminalText(
+          item.path
+        )}: ${convergence}.`
+      );
+    }
+  }
+
+  return warnings;
+};
+
+export const getFixDevMetrics = (lintResult: BatchLintItem[]): string[] => {
+  const lines: string[] = [];
+
+  for (const item of lintResult) {
+    const metrics = item.fixedResult?.metrics;
+    if (!metrics) {
+      continue;
+    }
+    const convergence = item.fixedResult?.convergence ?? "unknown";
+    const wallTime = metrics.wallTime.toFixed(2);
+    lines.push(
+      `[lint-md] Fix metrics: ${sanitizeTerminalText(
+        item.path
+      )}: convergence=${convergence}, rounds=${
+        metrics.rounds
+      }, wallTime=${wallTime}ms`
+    );
+  }
+
+  return lines;
+};


### PR DESCRIPTION
## 适配 core #182（已随 @lint-md/core 2.1.5 发布）

`FixedResult` 新增 `convergence: 'stable' | 'cycle' | 'max'` 可选字段。CLI 之前只读 `fixedResult.result`，对未知字段天然兼容；本 PR 是**功能增强**而非兼容修复。

### 行为
- **cycle / max** → 在 `--fix` 通过后输出 stderr 警告，文案：
  `[lint-md] Fix did not fully converge for <path>: cycle.`
  路径经 `sanitizeTerminalText` 清洗。**默认不改变退出码**（属质量警告，非硬错误）。
- **`-dev` 指标**：主线程拿到 `BatchLintItem[]` 后输出，避开 worker 多线程日志交错：
  `[lint-md] Fix metrics: <path>: convergence=<x>, rounds=<n>, wallTime=<x.xx>ms`
- **stdin --fix**：复用同一 warning helper，Markdown 写 stdout、warning 写 stderr，不混流。

### 关键决定
- `keepLintItem` 增加 `isIncompleteFix(item)` 分支。**显式**判定 `convergence === 'cycle' | 'max'`，不使用 `convergence !== 'stable'`——后者会让 pre-#182 core（convergence 为 undefined）被全部保留，破坏旧过滤语义。
- `isIncompleteFix` 用 core 暴露的 `FixConvergence` 枚举做白名单，避免把中文文案当 API。
- 不在 worker 内输出任何 dev 日志。
- **`--fail-on-incomplete-fix` 不在本 PR 范围**，留作后续 issue：它会引入新的 CLI 契约、帮助文本与 CI 行为测试，与本期安全可观测性增强分开评审更稳。

### 验证
- `npm run build && npm test`：15 套件 / 133 用例全过
- `npm run lint`（tsc --noEmit + prettier --check）：通过
- 新增 `__tests__/report-incomplete-fixes.spec.ts`（11 用例）与 `__tests__/keep-lint-item.spec.ts`（7 用例），全部用构造 `BatchLintItem`——不依赖无法序列化函数的 `.lintmdrc` E2E，符合 issue 要求
- 覆盖率：`report-incomplete-fixes.ts` 100%

### 文件
- 新增：`src/utils/report-incomplete-fixes.ts`
- 新增：`__tests__/report-incomplete-fixes.spec.ts`、`__tests__/keep-lint-item.spec.ts`
- 修改：`src/utils/batch-lint.ts`、`src/lint-md.ts`（2 处串入点）

Closes #98