### PR TITLE
fix: support core 2.2.1 not applied fixes

### DIFF
--- a/__tests__/batch-lint.spec.ts
+++ b/__tests__/batch-lint.spec.ts
@@ -12,6 +12,7 @@ import {
   runTasksWithLimit,
 } from "../src/utils/batch-lint";
 import type { BatchLintItem } from "../src/types";
+import { makeNotAppliedFix } from "./helpers/not-applied-fix";
 
 const makeItem = (overrides: Partial<BatchLintItem> = {}): BatchLintItem => ({
   path: "doc.md",
@@ -277,7 +278,7 @@ describe("keepLintItem", () => {
         makeItem({
           fixedResult: {
             result: "x",
-            notAppliedFixes: [{ range: [0, 1], text: "y" }],
+            notAppliedFixes: [makeNotAppliedFix([0, 1], "y")],
           },
         })
       )

--- a/__tests__/helpers/not-applied-fix.ts
+++ b/__tests__/helpers/not-applied-fix.ts
@@ -1,0 +1,11 @@
+import { FixNotAppliedReason, type NotAppliedFix } from "@lint-md/core";
+
+export const makeNotAppliedFix = (
+  range: [number, number],
+  text: string
+): NotAppliedFix => ({
+  range,
+  text,
+  targetRule: "test-rule",
+  reason: FixNotAppliedReason.OVERLAP,
+});

--- a/__tests__/keep-lint-item.spec.ts
+++ b/__tests__/keep-lint-item.spec.ts
@@ -2,6 +2,7 @@ import { keepLintItem } from "../src/utils/batch-lint";
 import { FixConvergence } from "@lint-md/core";
 import type { FixedResult } from "@lint-md/core";
 import type { BatchLintItem } from "../src/types";
+import { makeNotAppliedFix } from "./helpers/not-applied-fix";
 
 const baseItem = (
   overrides: Partial<BatchLintItem> & {
@@ -52,7 +53,7 @@ describe("keepLintItem", () => {
         baseItem({
           fixedResult: {
             result: "",
-            notAppliedFixes: [{ range: [0, 1], text: "x" }],
+            notAppliedFixes: [makeNotAppliedFix([0, 1], "x")],
           },
         })
       )

--- a/__tests__/report-unapplied-fixes.spec.ts
+++ b/__tests__/report-unapplied-fixes.spec.ts
@@ -1,5 +1,6 @@
 import { getUnappliedFixesWarnings } from "../src/utils/report-unapplied-fixes";
 import type { BatchLintItem } from "../src/types";
+import { makeNotAppliedFix } from "./helpers/not-applied-fix";
 
 const makeItem = (overrides: Partial<BatchLintItem> = {}): BatchLintItem => ({
   path: "doc.md",
@@ -30,7 +31,7 @@ describe("getUnappliedFixesWarnings", () => {
         path: "a.md",
         fixedResult: {
           result: "x",
-          notAppliedFixes: [{ range: [0, 1], text: "y" }],
+          notAppliedFixes: [makeNotAppliedFix([0, 1], "y")],
         },
       }),
     ];
@@ -46,9 +47,9 @@ describe("getUnappliedFixesWarnings", () => {
         fixedResult: {
           result: "x",
           notAppliedFixes: [
-            { range: [0, 1], text: "y" },
-            { range: [2, 3], text: "z" },
-            { range: [4, 5], text: "w" },
+            makeNotAppliedFix([0, 1], "y"),
+            makeNotAppliedFix([2, 3], "z"),
+            makeNotAppliedFix([4, 5], "w"),
           ],
         },
       }),
@@ -68,7 +69,7 @@ describe("getUnappliedFixesWarnings", () => {
         path: "bad.md",
         fixedResult: {
           result: "x",
-          notAppliedFixes: [{ range: [0, 1], text: "y" }],
+          notAppliedFixes: [makeNotAppliedFix([0, 1], "y")],
         },
       }),
     ];
@@ -83,7 +84,7 @@ describe("getUnappliedFixesWarnings", () => {
         path: "bad\u001B[31m.md\nnext-line",
         fixedResult: {
           result: "x",
-          notAppliedFixes: [{ range: [0, 1], text: "y" }],
+          notAppliedFixes: [makeNotAppliedFix([0, 1], "y")],
         },
       }),
     ];

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     ]
   },
   "dependencies": {
-    "@lint-md/core": "^2.1.6",
+    "@lint-md/core": "^2.2.1",
     "chalk": "^4",
     "commander": "^9.4.1",
     "glob": "^13.0.6",


### PR DESCRIPTION
## Summary

Upgrade `@lint-md/core` to `^2.2.1`.

Update CLI test fixtures for the new `NotAppliedFix` type.

## Root cause

Core now requires `targetRule` and `reason` in each `NotAppliedFix`.

CLI tests used the old fixture shape.

TypeScript failed when Jest compiled three test files.

## Changes

- Add a shared `makeNotAppliedFix` test helper.
- Add `targetRule` and `reason` to test fixtures.
- Update `@lint-md/core` to `^2.2.1`.

## Validation

- `npm run lint`
- `npm test`
- `npm run test:package`

All checks pass with `@lint-md/core@2.2.1`.