### PR TITLE
chore: prepare 2.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## [Unreleased]
 
+## [2.2.3](https://github.com/lint-md/cli/compare/v2.2.2...v2.2.3) (2026-07-29)
+
 ### Tests
 
 - add npm tarball smoke test for the packed CLI and installed `lint-md`, with a dedicated Node 22 CI job ([#103](https://github.com/lint-md/cli/issues/103), [#104](https://github.com/lint-md/cli/pull/104))
+- update `NotAppliedFix` test fixtures for `@lint-md/core` 2.2.1 ([#109](https://github.com/lint-md/cli/pull/109))
 
 ### Dependencies
 
 - upgrade `@lint-md/core` from `^2.1.5` to `^2.1.6` for parser 0.2.0 source-map fixes and accurate inline-code value ranges ([#104](https://github.com/lint-md/cli/pull/104))
+- upgrade `@lint-md/core` from `^2.1.6` to `^2.2.1` ([#109](https://github.com/lint-md/cli/pull/109))
 
 ## [2.2.2](https://github.com/lint-md/cli/compare/v2.1.1...v2.2.2) (2026-07-13)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lint-md/cli",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "CLI tool to lint your markdown file for Chinese.",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
## Summary

Prepare the 2.2.3 npm release.

## Changes

- Set the package version to 2.2.3.
- Add the 2.2.3 release notes.
- Record the core 2.2.1 compatibility update.

## Validation

- `npm run prepublishOnly`
- `npm pack --dry-run`

The checks ran with Node 22 and `@lint-md/core@2.2.1`.
