### PR TITLE
fix: define CLI-only package contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,6 @@
   "name": "@lint-md/cli",
   "version": "2.2.4",
   "description": "CLI tool to lint your markdown file for Chinese.",
-  "main": "lib/index.js",
-  "module": "esm/index.js",
   "bin": {
     "lint-md": "lib/src/lint-md.js"
   },
@@ -16,11 +14,10 @@
     "test": "jest --no-cache",
     "pretest": "npm run build",
     "build:cjs": "tsc -p tsconfig.json --target ESNext --module commonjs --outDir lib",
-    "build:esm": "tsc -p tsconfig.json --target ESNext --module ESNext --outDir esm",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "format": "prettier --write \"src/**/*.ts\" \"__tests__/**/*.ts\"",
     "lint": "npm run typecheck && prettier --check \"src/**/*.ts\" \"__tests__/**/*.ts\"",
-    "build": "rm -rf esm lib && run-p build:*",
+    "build": "rm -rf esm lib && npm run build:cjs",
     "clean": "rm -rf lib esm",
     "watch": "tsc -w",
     "cli-run": "node ./lib/src/lint-md.js examples/correct-title-trailing-punctuation.md",
@@ -30,8 +27,6 @@
     "prepublishOnly": "npm run lint && npm test && npm run test:package"
   },
   "files": [
-    "esm/package.json",
-    "esm/src",
     "lib/package.json",
     "lib/src",
     "CHANGELOG.md"
@@ -46,7 +41,6 @@
     "preset": "ts-jest",
     "testEnvironment": "node",
     "modulePathIgnorePatterns": [
-      "<rootDir>/esm/",
       "<rootDir>/lib/"
     ],
     "collectCoverage": true,
@@ -72,7 +66,6 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^22.9.3",
     "jest": "^30.0.0",
-    "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "ts-jest": "^29.0.3",
     "tsx": "^4.22.4",

--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -54,7 +54,6 @@ try {
     "CHANGELOG.md",
     "lib/src/lint-md.js",
     "lib/src/utils/lint-worker.js",
-    "esm/src/lint-md.js",
   ]) {
     assert(packedFiles.has(expectedFile), `tarball is missing ${expectedFile}`);
   }


### PR DESCRIPTION
## Summary

- Remove unsupported `main` and `module` package fields.
- Stop building and publishing the unused ESM tree.
- Remove the unused `npm-run-all` dependency.
- Keep the `lint-md` binary as the supported entry point.

## Reason

`@lint-md/cli` is an executable package.

Package-root imports are not part of its supported contract.

The ESM tree had no supported entry after removing `module`.

The dual build added package size and maintenance work.

## Impact

The supported CLI behavior does not change.

The package now builds and publishes only the CommonJS CLI tree.

This change does not add declarations or a package-root interface.

## Validation

- `npm run lint`
- `npm test` — 18 suites and 154 tests passed
- `npm run test:package`
- Confirmed the build leaves no `esm/` directory
- `git diff --check`

Closes #114 
Closes #115
