### PR TITLE
fix: build Docker image without lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22.22.1-alpine3.23 AS deps
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN npm install
 
 FROM deps AS builder
 COPY tsconfig.json ./
@@ -13,7 +13,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 COPY package*.json ./
 COPY --from=builder /app/lib ./lib
-RUN npm ci --omit=dev && npm cache clean --force
+RUN npm install --omit=dev && npm cache clean --force
 RUN chmod +x /app/lib/src/lint-md.js \
     && ln -s /app/lib/src/lint-md.js /usr/local/bin/lint-md \
     && chown -R node:node /app


### PR DESCRIPTION
## Summary

- Use `npm install` in the Docker dependency stage.
- Use `npm install --omit=dev` in the runtime stage.

## Root cause

The repository does not track `package-lock.json`.

Both Docker stages used `npm ci`, which requires a lockfile.

A clean repository context therefore failed during dependency installation.

## Impact

Docker images now build from a clean checkout without a lockfile.

The installed CLI behavior does not change.

## Validation

- Reproduced the original failure from `git archive HEAD`.
- Built the fixed image from the same clean context.
- Verified `lint-md --version`.
- Verified stdin lint.
- Verified file lint and file fix.
- `npm run lint`
- `npm test` — 18 suites and 154 tests passed
- `git diff --check`

Closes #108
