### PR TITLE
ci: run Docker smoke tests on related PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,11 @@
 name: docker
 
 on:
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - "package.json"
+      - ".github/workflows/docker.yml"
   workflow_dispatch:
 
 permissions:
@@ -17,6 +22,3 @@ jobs:
 
       - name: Smoke test - stdin lint
         run: echo "# Hello" | docker run -i lint-md-test --stdin
-
-      - name: Smoke test - file lint
-        run: docker run --rm -v ${{ github.workspace }}/examples:/docs:ro lint-md-test /docs/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "Dockerfile"
+      - ".dockerignore"
       - "package.json"
       - ".github/workflows/docker.yml"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Run Docker smoke checks on related pull requests.
- Limit triggers to Dockerfile, package metadata, and this workflow.
- Keep manual workflow dispatch available.
- Remove the example-directory lint step.

## Reason

PR #116 fixed a Docker build regression that normal CI did not detect.

The existing workflow only supported manual runs.

The examples directory contains intentional lint failures.

Running that directory would fail a required PR check.

## Impact

Unrelated pull requests do not run Docker builds.

Relevant pull requests verify the image build and stdin CLI path.

## Validation

- `npx prettier --check .github/workflows/docker.yml`
- `docker build -t lint-md-test .`
- `echo "# Hello" | docker run -i lint-md-test --stdin`
- `npm run lint`
- `git diff --check`

Follow-up to #116
