### PR TITLE
refactor: separate CLI startup

### DIFF
--- a/__tests__/cli.spec.ts
+++ b/__tests__/cli.spec.ts
@@ -1,20 +1,57 @@
 describe("cli tests", () => {
-  let mockExit: jest.SpyInstance;
+  const originalArgv = process.argv;
 
   beforeEach(() => {
-    process.argv = [];
     jest.resetModules();
-    mockExit = jest.spyOn(process, "exit").mockImplementation((() => {
-      throw new Error("process.exit");
-    }) as never);
   });
 
   afterEach(() => {
-    mockExit.mockRestore();
+    process.argv = originalArgv;
+    jest.restoreAllMocks();
   });
 
-  test("if user does not pass any argument, process.exit is called", () => {
-    expect(() => require("../src/lint-md")).toThrow("process.exit");
-    expect(mockExit).toHaveBeenCalled();
+  test("importing the CLI does not parse arguments or exit", () => {
+    process.argv = ["node", "lint-md", "--help"];
+    const mockExit = jest.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as never);
+
+    let cli!: typeof import("../src/lint-md");
+    expect(() => {
+      cli = require("../src/lint-md");
+    }).not.toThrow();
+
+    expect(cli.createProgram).toEqual(expect.any(Function));
+    expect(cli.main).toEqual(expect.any(Function));
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test("createProgram returns independent program instances", () => {
+    const { createProgram } = require("../src/lint-md");
+
+    const first = createProgram();
+    const second = createProgram();
+
+    expect(first).not.toBe(second);
+    expect(first.options.map(({ long }: { long: string }) => long)).toEqual([
+      "--version",
+      "--config",
+      "--fix",
+      "--dev",
+      "--threads",
+      "--suppress-warnings",
+      "--stdin",
+      "--max-file-size",
+    ]);
+  });
+
+  test("main shows help when no input is provided", () => {
+    const mockExit = jest.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as never);
+    const { main } = require("../src/lint-md");
+
+    expect(() => main(["node", "lint-md"])).toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(0);
   });
 });

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -7,7 +7,7 @@ const setExitCode = (code: number): void => {
 };
 import { readFileSync } from "fs";
 import { availableParallelism } from "os";
-import { program } from "commander";
+import { Command } from "commander";
 import { fixMarkdown, lintMarkdown } from "@lint-md/core";
 import { version } from "../package.json";
 import { safeWriteFile } from "./utils/safe-write-file";
@@ -34,128 +34,248 @@ import {
 import { emitExecutionErrorsAndSetExitCode } from "./utils/report-execution-errors";
 import { formatCoreError } from "./utils/format-core-error";
 
-program
-  .version(
-    version,
-    "-v, --version",
-    "output the version number（查看当前版本）"
-  )
-  .usage("<lint-md> [files...]")
-  .description("lint your markdown files")
-  .option(
-    "-c, --config [configure-file]",
-    "use the configure file, default .lintmdrc（使用配置文件，默认为 .lintmdrc）"
-  )
-  .option("-f, --fix", "fix the errors automatically（开启修复模式）")
-  .option("-d, --dev", "open dev mode（开启开发者模式）")
-  .option(
-    "-t, --threads [thread-count]",
-    'Number of worker threads, or "auto" to cap concurrency for large files. Default: CPU count.（执行 Lint / Fix 的线程数，传 "auto" 时根据文件大小自适应）'
-  )
-  .option(
-    "-s, --suppress-warnings",
-    "suppress all warnings, that means warnings will not block CI（抑制所有警告，这意味着警告不会阻止 CI）"
-  )
-  .option(
-    "-i, --stdin",
-    "read markdown content from stdin（从标准输入中读取内容）"
-  )
-  .option(
-    "--max-file-size <size>",
-    "skip Markdown files larger than <size> (e.g. 5mb, 500kb, 1gb), warn to stderr（跳过超过指定大小的 Markdown 文件）"
-  )
-  .arguments("[files...]")
-  .action(async (files: string[], options: CLIOptions) => {
-    const { fix, config, threads, dev, suppressWarnings, stdin, maxFileSize } =
-      options;
+export const createProgram = (): Command => {
+  const program = new Command();
 
-    const startTime = Date.now();
-    const isFixMode = Boolean(fix);
-    const isDev = Boolean(dev);
+  program
+    .version(
+      version,
+      "-v, --version",
+      "output the version number（查看当前版本）"
+    )
+    .usage("<lint-md> [files...]")
+    .description("lint your markdown files")
+    .option(
+      "-c, --config [configure-file]",
+      "use the configure file, default .lintmdrc（使用配置文件，默认为 .lintmdrc）"
+    )
+    .option("-f, --fix", "fix the errors automatically（开启修复模式）")
+    .option("-d, --dev", "open dev mode（开启开发者模式）")
+    .option(
+      "-t, --threads [thread-count]",
+      'Number of worker threads, or "auto" to cap concurrency for large files. Default: CPU count.（执行 Lint / Fix 的线程数，传 "auto" 时根据文件大小自适应）'
+    )
+    .option(
+      "-s, --suppress-warnings",
+      "suppress all warnings, that means warnings will not block CI（抑制所有警告，这意味着警告不会阻止 CI）"
+    )
+    .option(
+      "-i, --stdin",
+      "read markdown content from stdin（从标准输入中读取内容）"
+    )
+    .option(
+      "--max-file-size <size>",
+      "skip Markdown files larger than <size> (e.g. 5mb, 500kb, 1gb), warn to stderr（跳过超过指定大小的 Markdown 文件）"
+    )
+    .arguments("[files...]")
+    .action(async (files: string[], options: CLIOptions) => {
+      const {
+        fix,
+        config,
+        threads,
+        dev,
+        suppressWarnings,
+        stdin,
+        maxFileSize,
+      } = options;
 
-    if (isDev) {
-      console.log(`dev -- version: ${version}, ${new Date().toString()}`);
-    }
+      const startTime = Date.now();
+      const isFixMode = Boolean(fix);
+      const isDev = Boolean(dev);
 
-    const { rules, excludeFiles, extensions } = getLintConfig(config);
+      if (isDev) {
+        console.log(`dev -- version: ${version}, ${new Date().toString()}`);
+      }
 
-    // --threads 参数校验，所有分支共用
-    const threadCount: ThreadCount = getThreadCount(threads);
+      const { rules, excludeFiles, extensions } = getLintConfig(config);
 
-    // --max-file-size 校验（未传 = null = 不过滤），失败早退，与 --threads 一致
-    const maxFileSizeBytes = getMaxFileSizeOption(maxFileSize);
+      // --threads 参数校验，所有分支共用
+      const threadCount: ThreadCount = getThreadCount(threads);
 
-    // Handle stdin mode
-    if (stdin) {
-      const content = readFileSync(process.stdin.fd, "utf8");
+      // --max-file-size 校验（未传 = null = 不过滤），失败早退，与 --threads 一致
+      const maxFileSizeBytes = getMaxFileSizeOption(maxFileSize);
 
-      if (isFixMode) {
-        if (content.length === 0) {
-          return;
+      // Handle stdin mode
+      if (stdin) {
+        const content = readFileSync(process.stdin.fd, "utf8");
+
+        if (isFixMode) {
+          if (content.length === 0) {
+            return;
+          }
+
+          if (!content.trim()) {
+            process.stdout.write(content);
+            return;
+          }
+
+          try {
+            const result = fixMarkdown(content, { rules });
+            process.stdout.write(result.fixedResult?.result ?? content);
+            const stdinItem = {
+              path: "(stdin)",
+              lintResult: result.lintResult,
+              fixedResult: result.fixedResult,
+              fixableErrorCount: result.fixableErrorCount,
+              fixableWarningCount: result.fixableWarningCount,
+              executionErrors: result.executionErrors,
+            };
+            for (const warning of getIncompleteFixWarnings([stdinItem])) {
+              console.error(warning);
+            }
+            emitExecutionErrorsAndSetExitCode([stdinItem]);
+            if (isDev) {
+              for (const line of getFixDevMetrics([stdinItem])) {
+                console.error(line);
+              }
+            }
+            return;
+          } catch (e) {
+            const formatted = formatCoreError(e);
+            console.error(formatted.handled ? formatted.message : e);
+            process.exit(1);
+          }
         }
 
         if (!content.trim()) {
-          process.stdout.write(content);
-          return;
+          console.error("No content to lint");
+          process.exit(0);
         }
 
         try {
-          const result = fixMarkdown(content, { rules });
-          process.stdout.write(result.fixedResult?.result ?? content);
+          const result = lintMarkdown(content, rules, false);
           const stdinItem = {
             path: "(stdin)",
             lintResult: result.lintResult,
-            fixedResult: result.fixedResult,
             fixableErrorCount: result.fixableErrorCount,
             fixableWarningCount: result.fixableWarningCount,
             executionErrors: result.executionErrors,
           };
-          for (const warning of getIncompleteFixWarnings([stdinItem])) {
-            console.error(warning);
+          const { consoleMessage, errorCount, warningCount } = getReportData([
+            stdinItem,
+          ]);
+
+          console.log(consoleMessage);
+
+          const hasRuleFailures = emitExecutionErrorsAndSetExitCode([
+            stdinItem,
+          ]);
+
+          if (
+            errorCount > 0 ||
+            (!suppressWarnings && warningCount !== 0) ||
+            hasRuleFailures
+          ) {
+            setExitCode(1);
+            return;
           }
-          emitExecutionErrorsAndSetExitCode([stdinItem]);
-          if (isDev) {
-            for (const line of getFixDevMetrics([stdinItem])) {
-              console.error(line);
-            }
-          }
-          return;
         } catch (e) {
           const formatted = formatCoreError(e);
           console.error(formatted.handled ? formatted.message : e);
           process.exit(1);
         }
+
+        const endTime = new Date().getTime();
+        console.log(`⌛️Done in ${endTime - startTime}ms.`);
+        return;
       }
 
-      if (!content.trim()) {
-        console.error("No content to lint");
+      if (!files.length) {
+        return;
+      }
+
+      let mdFiles = await loadMdFiles(files, excludeFiles, extensions);
+
+      // 过滤超大文件（stderr warning + 跳过），发生在 resolveAdaptiveConcurrency
+      // 之前，使 --threads auto 只基于剩余文件重算并发，两者互不感知。
+      if (maxFileSizeBytes !== null) {
+        mdFiles = await filterFilesByMaxSize(mdFiles, maxFileSizeBytes);
+      }
+
+      if (!mdFiles.length) {
+        console.log("🎉 No markdown files to lint 🎉");
         process.exit(0);
+        return;
+      }
+
+      const effectiveThreads = await resolveAdaptiveConcurrency(
+        threadCount,
+        mdFiles
+      );
+
+      if (isDev && threadCount === "auto") {
+        const maxFileSize = await getMaxFileSize(mdFiles);
+        const adaptiveApplied = maxFileSize >= 1024 * 1024;
+        const requested = availableParallelism();
+        if (adaptiveApplied && effectiveThreads < requested) {
+          const maxMiB = (maxFileSize / (1024 * 1024)).toFixed(2);
+          console.log(
+            `[lint-md] Adaptive concurrency: requested auto, effective ${effectiveThreads}, max file ${maxMiB} MiB`
+          );
+        }
       }
 
       try {
-        const result = lintMarkdown(content, rules, false);
-        const stdinItem = {
-          path: "(stdin)",
-          lintResult: result.lintResult,
-          fixableErrorCount: result.fixableErrorCount,
-          fixableWarningCount: result.fixableWarningCount,
-          executionErrors: result.executionErrors,
-        };
-        const { consoleMessage, errorCount, warningCount } = getReportData([
-          stdinItem,
-        ]);
+        const { allResults, actionableResults } = await batchLint(
+          effectiveThreads,
+          mdFiles,
+          isFixMode,
+          rules
+        );
 
-        console.log(consoleMessage);
+        if (!isFixMode) {
+          const { consoleMessage, errorCount, warningCount } =
+            getReportData(actionableResults);
 
-        const hasRuleFailures = emitExecutionErrorsAndSetExitCode([stdinItem]);
+          console.log(consoleMessage);
 
-        if (
-          errorCount > 0 ||
-          (!suppressWarnings && warningCount !== 0) ||
-          hasRuleFailures
-        ) {
-          setExitCode(1);
-          return;
+          const hasRuleFailures =
+            emitExecutionErrorsAndSetExitCode(actionableResults);
+
+          if (
+            errorCount > 0 ||
+            (!suppressWarnings && warningCount !== 0) ||
+            hasRuleFailures
+          ) {
+            setExitCode(1);
+            return;
+          }
+        } else {
+          await runTasksWithLimit(
+            actionableResults
+              .filter(({ fixedResult }) => fixedResult)
+              .map(
+                ({ path, fixedResult }) =>
+                  () =>
+                    safeWriteFile(path, fixedResult!.result)
+              ),
+            effectiveThreads
+          );
+
+          for (const warning of getIncompleteFixWarnings(actionableResults)) {
+            console.error(warning);
+          }
+          for (const warning of getUnappliedFixesWarnings(actionableResults)) {
+            console.error(warning);
+          }
+          const hasRuleFailures =
+            emitExecutionErrorsAndSetExitCode(actionableResults);
+
+          if (isDev) {
+            for (const line of getFixDevMetrics(allResults)) {
+              console.log(line);
+            }
+          }
+
+          // Rule execution errors (core #185) are hard failures: emitted above
+          // (after the fixes are written) and failed the CI run regardless of
+          // --suppress-warnings. emitExecutionErrorsAndSetExitCode already set
+          // process.exitCode = 1 so the written files and diagnostics flush.
+          // Early-return so we don't print a trailing "Done in …" on failure,
+          // matching the previous process.exit(1) behaviour.
+          if (hasRuleFailures) {
+            return;
+          }
         }
       } catch (e) {
         const formatted = formatCoreError(e);
@@ -163,121 +283,23 @@ program
         process.exit(1);
       }
 
-      const endTime = new Date().getTime();
+      const endTime = Date.now();
       console.log(`⌛️Done in ${endTime - startTime}ms.`);
-      return;
-    }
+    });
 
-    if (!files.length) {
-      return;
-    }
+  return program;
+};
 
-    let mdFiles = await loadMdFiles(files, excludeFiles, extensions);
+export const main = (argv: string[] = process.argv): void => {
+  const program = createProgram();
+  program.parse(argv);
 
-    // 过滤超大文件（stderr warning + 跳过），发生在 resolveAdaptiveConcurrency
-    // 之前，使 --threads auto 只基于剩余文件重算并发，两者互不感知。
-    if (maxFileSizeBytes !== null) {
-      mdFiles = await filterFilesByMaxSize(mdFiles, maxFileSizeBytes);
-    }
+  const isStdin = argv.includes("--stdin") || argv.includes("-i");
+  if (!program.args.length && !isStdin) {
+    program.help();
+  }
+};
 
-    if (!mdFiles.length) {
-      console.log("🎉 No markdown files to lint 🎉");
-      process.exit(0);
-      return;
-    }
-
-    const effectiveThreads = await resolveAdaptiveConcurrency(
-      threadCount,
-      mdFiles
-    );
-
-    if (isDev && threadCount === "auto") {
-      const maxFileSize = await getMaxFileSize(mdFiles);
-      const adaptiveApplied = maxFileSize >= 1024 * 1024;
-      const requested = availableParallelism();
-      if (adaptiveApplied && effectiveThreads < requested) {
-        const maxMiB = (maxFileSize / (1024 * 1024)).toFixed(2);
-        console.log(
-          `[lint-md] Adaptive concurrency: requested auto, effective ${effectiveThreads}, max file ${maxMiB} MiB`
-        );
-      }
-    }
-
-    try {
-      const { allResults, actionableResults } = await batchLint(
-        effectiveThreads,
-        mdFiles,
-        isFixMode,
-        rules
-      );
-
-      if (!isFixMode) {
-        const { consoleMessage, errorCount, warningCount } =
-          getReportData(actionableResults);
-
-        console.log(consoleMessage);
-
-        const hasRuleFailures =
-          emitExecutionErrorsAndSetExitCode(actionableResults);
-
-        if (
-          errorCount > 0 ||
-          (!suppressWarnings && warningCount !== 0) ||
-          hasRuleFailures
-        ) {
-          setExitCode(1);
-          return;
-        }
-      } else {
-        await runTasksWithLimit(
-          actionableResults
-            .filter(({ fixedResult }) => fixedResult)
-            .map(
-              ({ path, fixedResult }) =>
-                () =>
-                  safeWriteFile(path, fixedResult!.result)
-            ),
-          effectiveThreads
-        );
-
-        for (const warning of getIncompleteFixWarnings(actionableResults)) {
-          console.error(warning);
-        }
-        for (const warning of getUnappliedFixesWarnings(actionableResults)) {
-          console.error(warning);
-        }
-        const hasRuleFailures =
-          emitExecutionErrorsAndSetExitCode(actionableResults);
-
-        if (isDev) {
-          for (const line of getFixDevMetrics(allResults)) {
-            console.log(line);
-          }
-        }
-
-        // Rule execution errors (core #185) are hard failures: emitted above
-        // (after the fixes are written) and failed the CI run regardless of
-        // --suppress-warnings. emitExecutionErrorsAndSetExitCode already set
-        // process.exitCode = 1 so the written files and diagnostics flush.
-        // Early-return so we don't print a trailing "Done in …" on failure,
-        // matching the previous process.exit(1) behaviour.
-        if (hasRuleFailures) {
-          return;
-        }
-      }
-    } catch (e) {
-      const formatted = formatCoreError(e);
-      console.error(formatted.handled ? formatted.message : e);
-      process.exit(1);
-    }
-
-    const endTime = Date.now();
-    console.log(`⌛️Done in ${endTime - startTime}ms.`);
-  });
-
-program.parse(process.argv);
-
-const isStdin = process.argv.includes("--stdin") || process.argv.includes("-i");
-if (!program.args.length && !isStdin) {
-  program.help();
+if (require.main === module) {
+  main();
 }


### PR DESCRIPTION
## Summary

- Add `createProgram()` for independent Commander instances.
- Add `main(argv)` for explicit process startup.
- Start the CLI only during direct binary execution.
- Replace the import-side-effect test with direct startup tests.

## Reason

Importing `src/lint-md.ts` previously parsed `process.argv` immediately.

The import could print help or exit the process.

The global Commander instance also retained parse state.

## Impact

CLI imports no longer cause process side effects.

Tests can use the program definition and startup seams directly.

The existing lint and fix action flow remains unchanged.

Prettier reindented the action after placing it inside `createProgram()`.

Use a whitespace-ignored diff to review the logical change.

## Validation

- `npm run lint`
- `npm test` — 18 suites and 156 tests passed
- `npm run test:package`
- Verified help, version, and stdin through `tsx`
- `git diff --check`

Closes #118
