### PR TITLE
fix: await asynchronous CLI actions

### DIFF
--- a/__tests__/cli.spec.ts
+++ b/__tests__/cli.spec.ts
@@ -7,6 +7,7 @@ describe("cli tests", () => {
 
   afterEach(() => {
     process.argv = originalArgv;
+    jest.dontMock("../src/utils/load-md-files");
     jest.restoreAllMocks();
   });
 
@@ -45,13 +46,42 @@ describe("cli tests", () => {
     ]);
   });
 
-  test("main shows help when no input is provided", () => {
+  test("main waits for asynchronous actions", async () => {
+    let resolveFiles!: (files: string[]) => void;
+    const files = new Promise<string[]>((resolve) => {
+      resolveFiles = resolve;
+    });
+    const loadMdFiles = jest.fn(() => files);
+    jest.doMock("../src/utils/load-md-files", () => ({ loadMdFiles }));
+    const mockExit = jest
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    jest.spyOn(console, "log").mockImplementation();
+    const { main } = require("../src/lint-md");
+
+    let settled = false;
+    const result = main(["node", "lint-md", "fixture.md"]).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveFiles([]);
+    await result;
+
+    expect(settled).toBe(true);
+    expect(loadMdFiles).toHaveBeenCalledTimes(1);
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
+  test("main shows help when no input is provided", async () => {
     const mockExit = jest.spyOn(process, "exit").mockImplementation((() => {
       throw new Error("process.exit");
     }) as never);
     const { main } = require("../src/lint-md");
 
-    expect(() => main(["node", "lint-md"])).toThrow("process.exit");
+    await expect(main(["node", "lint-md"])).rejects.toThrow("process.exit");
     expect(mockExit).toHaveBeenCalledWith(0);
   });
 });

--- a/__tests__/cli.spec.ts
+++ b/__tests__/cli.spec.ts
@@ -1,5 +1,6 @@
 describe("cli tests", () => {
   const originalArgv = process.argv;
+  const originalExitCode = process.exitCode;
 
   beforeEach(() => {
     jest.resetModules();
@@ -7,6 +8,7 @@ describe("cli tests", () => {
 
   afterEach(() => {
     process.argv = originalArgv;
+    process.exitCode = originalExitCode;
     jest.dontMock("../src/utils/load-md-files");
     jest.restoreAllMocks();
   });
@@ -73,6 +75,21 @@ describe("cli tests", () => {
     expect(settled).toBe(true);
     expect(loadMdFiles).toHaveBeenCalledTimes(1);
     expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
+  test("runCli handles rejected actions", async () => {
+    const error = new Error("load failed");
+    const loadMdFiles = jest.fn(() => Promise.reject(error));
+    jest.doMock("../src/utils/load-md-files", () => ({ loadMdFiles }));
+    const mockError = jest.spyOn(console, "error").mockImplementation();
+    const { runCli } = require("../src/lint-md");
+
+    process.exitCode = undefined;
+    runCli(["node", "lint-md", "fixture.md"]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(mockError).toHaveBeenCalledWith(error);
+    expect(process.exitCode).toBe(1);
   });
 
   test("main shows help when no input is provided", async () => {

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -290,9 +290,9 @@ export const createProgram = (): Command => {
   return program;
 };
 
-export const main = (argv: string[] = process.argv): void => {
+export const main = async (argv: string[] = process.argv): Promise<void> => {
   const program = createProgram();
-  program.parse(argv);
+  await program.parseAsync(argv);
 
   const isStdin = argv.includes("--stdin") || argv.includes("-i");
   if (!program.args.length && !isStdin) {
@@ -301,5 +301,5 @@ export const main = (argv: string[] = process.argv): void => {
 };
 
 if (require.main === module) {
-  main();
+  void main();
 }

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -300,6 +300,13 @@ export const main = async (argv: string[] = process.argv): Promise<void> => {
   }
 };
 
+export const runCli = (argv: string[] = process.argv): void => {
+  void main(argv).catch((error) => {
+    console.error(error);
+    setExitCode(1);
+  });
+};
+
 if (require.main === module) {
-  void main();
+  runCli();
 }


### PR DESCRIPTION
Follow-up to #119.

## Summary

- Make `main()` return `Promise<void>`.
- Use `parseAsync()` to wait for asynchronous Commander actions.
- Keep rejected promises available to embedded callers.
- Handle direct startup failures in `runCli()`.
- Print direct startup failures to stderr.
- Set the process exit code to 1 after a startup failure.
- Add regression tests for asynchronous completion and rejection handling.

## Validation

- `npm test -- --runInBand`
- `npm run lint`
- `npm run test:package`