### PR TITLE
refactor: remove unsupported library type exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,0 @@
-// type declarations
-export { CLILintResult, CLIConfig, CliErrorCount, CLIOptions } from "./types";

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -22,7 +22,7 @@ import {
   getMaxFileSizeOption,
   getThreadCount,
 } from "./utils/configure";
-import type { CLIOptions, ThreadCount } from "./types";
+import type { ThreadCount } from "./types";
 import { loadMdFiles } from "./utils/load-md-files";
 import { getReportData } from "./utils/get-report-data";
 import { filterFilesByMaxSize } from "./utils/filter-by-max-size";
@@ -33,6 +33,16 @@ import {
 } from "./utils/report-incomplete-fixes";
 import { emitExecutionErrorsAndSetExitCode } from "./utils/report-execution-errors";
 import { formatCoreError } from "./utils/format-core-error";
+
+interface CLIOptions {
+  fix?: boolean;
+  dev?: boolean;
+  config?: string;
+  suppressWarnings: boolean;
+  threads?: string | boolean;
+  stdin?: boolean;
+  maxFileSize?: string;
+}
 
 export const createProgram = (): Command => {
   const program = new Command();

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,29 +14,6 @@ export interface CLIConfig {
   extensions?: string[];
 }
 
-/** 用户传入的 CLI 选项 */
-export interface CLIOptions {
-  fix?: boolean;
-  dev?: boolean;
-  config?: string;
-  suppressWarnings: boolean;
-  threads?: string | boolean;
-  stdin?: boolean;
-  maxFileSize?: string;
-}
-
-/** CLI lint 结果选项 */
-export interface CLILintResult {
-  path: string;
-  file: string;
-}
-
-/** CLI lint 错误统计信息 */
-export interface CliErrorCount {
-  error: number;
-  warning: number;
-}
-
 export interface LintWorkerOptions {
   filePath: string;
   rules?: LintMdRulesConfig;


### PR DESCRIPTION
Closes #121.

## Summary

- Delete the unused `src/index.ts` library entry.
- Delete `CLILintResult` and `CliErrorCount`.
- Move `CLIOptions` to `src/lint-md.ts`.
- Keep shared configuration, worker, and batch types.

## Reason

`@lint-md/cli` supports the `lint-md` binary only. These exports do not form a supported package interface.

## Validation

- `npm run lint`
- `npm test -- --runInBand`
- `npm run test:package`
- `npm pack --dry-run`