### PR TITLE
refactor: reuse adaptive concurrency diagnostics

### DIFF
--- a/__tests__/batch-lint.spec.ts
+++ b/__tests__/batch-lint.spec.ts
@@ -386,12 +386,20 @@ describe("resolveAdaptiveConcurrency", () => {
         writeSizedFile("b.md", 100),
         writeSizedFile("c.md", 100),
       ]);
-      expect(await resolveAdaptiveConcurrency(2, files)).toBe(2);
+      expect(await resolveAdaptiveConcurrency(2, files)).toEqual({
+        concurrency: 2,
+        maxFileSize: null,
+        requestedConcurrency: 2,
+      });
     });
 
     test("numeric threads > fileCount is clamped to fileCount", async () => {
       const file = await writeSizedFile("only.md", 100);
-      expect(await resolveAdaptiveConcurrency(100, [file])).toBe(1);
+      expect(await resolveAdaptiveConcurrency(100, [file])).toEqual({
+        concurrency: 1,
+        maxFileSize: null,
+        requestedConcurrency: 100,
+      });
     });
 
     test("numeric 0 is clamped to 1 (matches existing min clamp)", async () => {
@@ -399,7 +407,11 @@ describe("resolveAdaptiveConcurrency", () => {
         writeSizedFile("a.md", 100),
         writeSizedFile("b.md", 100),
       ]);
-      expect(await resolveAdaptiveConcurrency(0, files)).toBe(1);
+      expect(await resolveAdaptiveConcurrency(0, files)).toEqual({
+        concurrency: 1,
+        maxFileSize: null,
+        requestedConcurrency: 0,
+      });
     });
 
     test("numeric threads ignores file size", async () => {
@@ -409,13 +421,21 @@ describe("resolveAdaptiveConcurrency", () => {
         )
       );
 
-      expect(await resolveAdaptiveConcurrency(8, files)).toBe(8);
+      expect(await resolveAdaptiveConcurrency(8, files)).toEqual({
+        concurrency: 8,
+        maxFileSize: null,
+        requestedConcurrency: 8,
+      });
     });
   });
 
   describe("auto threadCount", () => {
     test("empty file list → 0", async () => {
-      expect(await resolveAdaptiveConcurrency("auto", [])).toBe(0);
+      expect(await resolveAdaptiveConcurrency("auto", [])).toEqual({
+        concurrency: 0,
+        maxFileSize: 0,
+        requestedConcurrency: availableParallelism(),
+      });
     });
 
     test("small files (< 1 MiB) use cpuLimit clamped to fileCount", async () => {
@@ -425,9 +445,11 @@ describe("resolveAdaptiveConcurrency", () => {
         writeSizedFile("c.md", 4096),
       ]);
       const cpuLimit = availableParallelism();
-      expect(await resolveAdaptiveConcurrency("auto", files)).toBe(
-        Math.min(cpuLimit, files.length)
-      );
+      expect(await resolveAdaptiveConcurrency("auto", files)).toEqual({
+        concurrency: Math.min(cpuLimit, files.length),
+        maxFileSize: 4096,
+        requestedConcurrency: cpuLimit,
+      });
     });
 
     test("max file exactly 1 MiB caps at 2", async () => {
@@ -435,36 +457,57 @@ describe("resolveAdaptiveConcurrency", () => {
         writeSizedFile("small.md", 1024),
         writeSizedFile("one-mib.md", 1024 * 1024),
       ]);
-      expect(
-        await resolveAdaptiveConcurrency("auto", files)
-      ).toBeLessThanOrEqual(2);
+      const cpuLimit = availableParallelism();
+      expect(await resolveAdaptiveConcurrency("auto", files)).toEqual({
+        concurrency: Math.min(cpuLimit, 2, files.length),
+        maxFileSize: 1024 * 1024,
+        requestedConcurrency: cpuLimit,
+      });
     });
 
     test("max file 1.5 MiB caps at 2", async () => {
       const file = await writeSizedFile("medium.md", 1.5 * 1024 * 1024);
-      expect(
-        await resolveAdaptiveConcurrency("auto", [file])
-      ).toBeLessThanOrEqual(2);
+      expect(await resolveAdaptiveConcurrency("auto", [file])).toEqual({
+        concurrency: 1,
+        maxFileSize: 1.5 * 1024 * 1024,
+        requestedConcurrency: availableParallelism(),
+      });
     });
 
     test("max file exactly 5 MiB forces 1", async () => {
       const file = await writeSizedFile("five-mib.md", 5 * 1024 * 1024);
-      expect(await resolveAdaptiveConcurrency("auto", [file])).toBe(1);
+      expect(await resolveAdaptiveConcurrency("auto", [file])).toEqual({
+        concurrency: 1,
+        maxFileSize: 5 * 1024 * 1024,
+        requestedConcurrency: availableParallelism(),
+      });
     });
 
     test("max file 6 MiB forces 1", async () => {
       const file = await writeSizedFile("six-mib.md", 6 * 1024 * 1024);
-      expect(await resolveAdaptiveConcurrency("auto", [file])).toBe(1);
+      expect(await resolveAdaptiveConcurrency("auto", [file])).toEqual({
+        concurrency: 1,
+        maxFileSize: 6 * 1024 * 1024,
+        requestedConcurrency: availableParallelism(),
+      });
     });
 
     test("single small file → 1", async () => {
       const file = await writeSizedFile("only.md", 100);
-      expect(await resolveAdaptiveConcurrency("auto", [file])).toBe(1);
+      expect(await resolveAdaptiveConcurrency("auto", [file])).toEqual({
+        concurrency: 1,
+        maxFileSize: 100,
+        requestedConcurrency: availableParallelism(),
+      });
     });
 
     test("medium cap respects fileCount when files < 2", async () => {
       const file = await writeSizedFile("one-mib.md", 1.2 * 1024 * 1024);
-      expect(await resolveAdaptiveConcurrency("auto", [file])).toBe(1);
+      expect(await resolveAdaptiveConcurrency("auto", [file])).toEqual({
+        concurrency: 1,
+        maxFileSize: Math.floor(1.2 * 1024 * 1024),
+        requestedConcurrency: availableParallelism(),
+      });
     });
   });
 });

--- a/__tests__/batch-lint.spec.ts
+++ b/__tests__/batch-lint.spec.ts
@@ -420,12 +420,18 @@ describe("resolveAdaptiveConcurrency", () => {
           writeSizedFile(`huge-${index}.md`, 10 * 1024 * 1024)
         )
       );
+      const statSpy = jest.spyOn(require("fs/promises"), "stat");
 
-      expect(await resolveAdaptiveConcurrency(8, files)).toEqual({
-        concurrency: 8,
-        maxFileSize: null,
-        requestedConcurrency: 8,
-      });
+      try {
+        expect(await resolveAdaptiveConcurrency(8, files)).toEqual({
+          concurrency: 8,
+          maxFileSize: null,
+          requestedConcurrency: 8,
+        });
+        expect(statSpy).not.toHaveBeenCalled();
+      } finally {
+        statSpy.mockRestore();
+      }
     });
   });
 
@@ -445,11 +451,18 @@ describe("resolveAdaptiveConcurrency", () => {
         writeSizedFile("c.md", 4096),
       ]);
       const cpuLimit = availableParallelism();
-      expect(await resolveAdaptiveConcurrency("auto", files)).toEqual({
-        concurrency: Math.min(cpuLimit, files.length),
-        maxFileSize: 4096,
-        requestedConcurrency: cpuLimit,
-      });
+      const statSpy = jest.spyOn(require("fs/promises"), "stat");
+
+      try {
+        expect(await resolveAdaptiveConcurrency("auto", files)).toEqual({
+          concurrency: Math.min(cpuLimit, files.length),
+          maxFileSize: 4096,
+          requestedConcurrency: cpuLimit,
+        });
+        expect(statSpy).toHaveBeenCalledTimes(files.length);
+      } finally {
+        statSpy.mockRestore();
+      }
     });
 
     test("max file exactly 1 MiB caps at 2", async () => {

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -6,14 +6,12 @@ const setExitCode = (code: number): void => {
   (globalThis as { process?: NodeJS.Process }).process!.exitCode = code;
 };
 import { readFileSync } from "fs";
-import { availableParallelism } from "os";
 import { Command } from "commander";
 import { fixMarkdown, lintMarkdown } from "@lint-md/core";
 import { version } from "../package.json";
 import { safeWriteFile } from "./utils/safe-write-file";
 import {
   batchLint,
-  getMaxFileSize,
   resolveAdaptiveConcurrency,
   runTasksWithLimit,
 } from "./utils/batch-lint";
@@ -208,16 +206,16 @@ export const createProgram = (): Command => {
         return;
       }
 
-      const effectiveThreads = await resolveAdaptiveConcurrency(
+      const concurrencyDecision = await resolveAdaptiveConcurrency(
         threadCount,
         mdFiles
       );
+      const effectiveThreads = concurrencyDecision.concurrency;
 
-      if (isDev && threadCount === "auto") {
-        const maxFileSize = await getMaxFileSize(mdFiles);
+      if (isDev && concurrencyDecision.maxFileSize !== null) {
+        const { maxFileSize, requestedConcurrency } = concurrencyDecision;
         const adaptiveApplied = maxFileSize >= 1024 * 1024;
-        const requested = availableParallelism();
-        if (adaptiveApplied && effectiveThreads < requested) {
+        if (adaptiveApplied && effectiveThreads < requestedConcurrency) {
           const maxMiB = (maxFileSize / (1024 * 1024)).toFixed(2);
           console.log(
             `[lint-md] Adaptive concurrency: requested auto, effective ${effectiveThreads}, max file ${maxMiB} MiB`

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -65,29 +65,49 @@ export const getMaxFileSize = async (filePaths: string[]): Promise<number> => {
   return sizes.reduce((max, current) => (current > max ? current : max), 0);
 };
 
+export interface AdaptiveConcurrencyDecision {
+  concurrency: number;
+  maxFileSize: number | null;
+  requestedConcurrency: number;
+}
+
 export const resolveAdaptiveConcurrency = async (
   threadCount: ThreadCount,
   mdFilePaths: string[]
-): Promise<number> => {
+): Promise<AdaptiveConcurrencyDecision> => {
+  const requestedConcurrency =
+    typeof threadCount === "number" ? threadCount : availableParallelism();
+
   if (mdFilePaths.length === 0) {
-    return 0;
+    return {
+      concurrency: 0,
+      maxFileSize: threadCount === "auto" ? 0 : null,
+      requestedConcurrency,
+    };
   }
 
   if (typeof threadCount === "number") {
-    return Math.min(Math.max(threadCount, 1), mdFilePaths.length);
+    return {
+      concurrency: Math.min(Math.max(threadCount, 1), mdFilePaths.length),
+      maxFileSize: null,
+      requestedConcurrency,
+    };
   }
 
   const maxFileSize = await getMaxFileSize(mdFilePaths);
-  const cpuLimit = availableParallelism();
 
-  let limit = cpuLimit;
+  let limit = requestedConcurrency;
   if (maxFileSize >= ADAPTIVE_HUGE_FILE_THRESHOLD) {
     limit = 1;
   } else if (maxFileSize >= ADAPTIVE_LARGE_FILE_THRESHOLD) {
     limit = Math.min(limit, ADAPTIVE_MEDIUM_CAP);
   }
 
-  return Math.min(Math.max(limit, 1), mdFilePaths.length);
+  return {
+    concurrency: Math.min(Math.max(limit, 1), mdFilePaths.length),
+    maxFileSize,
+    requestedConcurrency,
+  };
 };
 
 // Keep a file's result when it has lint findings, or — in fix mode — when


### PR DESCRIPTION
Closes #123.

## Summary

- Return execution and diagnostic data from `resolveAdaptiveConcurrency()`.
- Reuse the measured maximum file size in development output.
- Keep numeric thread mode free from file size scans.
- Assert exact `stat()` call counts for numeric and auto decisions.

## Reason

`--threads auto --dev` scanned every Markdown file twice. The second scan only supplied development output.

The CLI now uses the same decision data for execution and diagnostics.

## Validation

- `npm test -- --runInBand __tests__/batch-lint.spec.ts`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run test:package`