### PR TITLE
refactor: extract stdin lint flow

### DIFF
--- a/__tests__/run-stdin-lint.spec.ts
+++ b/__tests__/run-stdin-lint.spec.ts
@@ -1,0 +1,65 @@
+import { runStdinLint } from "../src/cli/run-lint";
+
+describe("runStdinLint", () => {
+  const originalExitCode = process.exitCode;
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    jest.restoreAllMocks();
+  });
+
+  test("passes whitespace through unchanged in fix mode", () => {
+    const write = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation((() => true) as never);
+
+    runStdinLint({
+      content: "   \n\n",
+      isDev: false,
+      isFixMode: true,
+      rules: {},
+      startTime: 0,
+      suppressWarnings: false,
+    });
+
+    expect(write).toHaveBeenCalledWith("   \n\n");
+  });
+
+  test("exits successfully when lint input has no content", () => {
+    const error = jest.spyOn(console, "error").mockImplementation();
+    const exit = jest.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as never);
+
+    expect(() =>
+      runStdinLint({
+        content: " \n",
+        isDev: false,
+        isFixMode: false,
+        rules: {},
+        startTime: 0,
+        suppressWarnings: false,
+      })
+    ).toThrow("process.exit");
+
+    expect(error).toHaveBeenCalledWith("No content to lint");
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  test("reports timing after a clean lint", () => {
+    const log = jest.spyOn(console, "log").mockImplementation();
+    jest.spyOn(Date, "now").mockReturnValue(125);
+
+    runStdinLint({
+      content: "# Hello\n",
+      isDev: false,
+      isFixMode: false,
+      rules: {},
+      startTime: 100,
+      suppressWarnings: false,
+    });
+
+    expect(log).toHaveBeenCalledWith("");
+    expect(log).toHaveBeenCalledWith("⌛️Done in 25ms.");
+  });
+});

--- a/src/cli/run-lint.ts
+++ b/src/cli/run-lint.ts
@@ -1,0 +1,110 @@
+import * as process from "process";
+import { fixMarkdown, lintMarkdown } from "@lint-md/core";
+import type { LintMdRulesConfig } from "@lint-md/core";
+import type { BatchLintItem } from "../types";
+import { formatCoreError } from "../utils/format-core-error";
+import { getReportData } from "../utils/get-report-data";
+import {
+  getFixDevMetrics,
+  getIncompleteFixWarnings,
+} from "../utils/report-incomplete-fixes";
+import { emitExecutionErrorsAndSetExitCode } from "../utils/report-execution-errors";
+
+interface RunStdinLintOptions {
+  content: string;
+  isDev: boolean;
+  isFixMode: boolean;
+  rules: LintMdRulesConfig;
+  startTime: number;
+  suppressWarnings: boolean;
+}
+
+const setExitCode = (code: number): void => {
+  (globalThis as { process?: NodeJS.Process }).process!.exitCode = code;
+};
+
+export const runStdinLint = ({
+  content,
+  isDev,
+  isFixMode,
+  rules,
+  startTime,
+  suppressWarnings,
+}: RunStdinLintOptions): void => {
+  if (isFixMode) {
+    if (content.length === 0) {
+      return;
+    }
+
+    if (!content.trim()) {
+      process.stdout.write(content);
+      return;
+    }
+
+    try {
+      const result = fixMarkdown(content, { rules });
+      process.stdout.write(result.fixedResult?.result ?? content);
+      const stdinItem: BatchLintItem = {
+        path: "(stdin)",
+        lintResult: result.lintResult,
+        fixedResult: result.fixedResult,
+        fixableErrorCount: result.fixableErrorCount,
+        fixableWarningCount: result.fixableWarningCount,
+        executionErrors: result.executionErrors,
+      };
+      for (const warning of getIncompleteFixWarnings([stdinItem])) {
+        console.error(warning);
+      }
+      emitExecutionErrorsAndSetExitCode([stdinItem]);
+      if (isDev) {
+        for (const line of getFixDevMetrics([stdinItem])) {
+          console.error(line);
+        }
+      }
+      return;
+    } catch (error) {
+      const formatted = formatCoreError(error);
+      console.error(formatted.handled ? formatted.message : error);
+      process.exit(1);
+    }
+  }
+
+  if (!content.trim()) {
+    console.error("No content to lint");
+    process.exit(0);
+  }
+
+  try {
+    const result = lintMarkdown(content, rules, false);
+    const stdinItem: BatchLintItem = {
+      path: "(stdin)",
+      lintResult: result.lintResult,
+      fixableErrorCount: result.fixableErrorCount,
+      fixableWarningCount: result.fixableWarningCount,
+      executionErrors: result.executionErrors,
+    };
+    const { consoleMessage, errorCount, warningCount } = getReportData([
+      stdinItem,
+    ]);
+
+    console.log(consoleMessage);
+
+    const hasRuleFailures = emitExecutionErrorsAndSetExitCode([stdinItem]);
+
+    if (
+      errorCount > 0 ||
+      (!suppressWarnings && warningCount !== 0) ||
+      hasRuleFailures
+    ) {
+      setExitCode(1);
+      return;
+    }
+  } catch (error) {
+    const formatted = formatCoreError(error);
+    console.error(formatted.handled ? formatted.message : error);
+    process.exit(1);
+  }
+
+  const endTime = Date.now();
+  console.log(`⌛️Done in ${endTime - startTime}ms.`);
+};

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -7,8 +7,8 @@ const setExitCode = (code: number): void => {
 };
 import { readFileSync } from "fs";
 import { Command } from "commander";
-import { fixMarkdown, lintMarkdown } from "@lint-md/core";
 import { version } from "../package.json";
+import { runStdinLint } from "./cli/run-lint";
 import { safeWriteFile } from "./utils/safe-write-file";
 import {
   batchLint,
@@ -106,85 +106,14 @@ export const createProgram = (): Command => {
       // Handle stdin mode
       if (stdin) {
         const content = readFileSync(process.stdin.fd, "utf8");
-
-        if (isFixMode) {
-          if (content.length === 0) {
-            return;
-          }
-
-          if (!content.trim()) {
-            process.stdout.write(content);
-            return;
-          }
-
-          try {
-            const result = fixMarkdown(content, { rules });
-            process.stdout.write(result.fixedResult?.result ?? content);
-            const stdinItem = {
-              path: "(stdin)",
-              lintResult: result.lintResult,
-              fixedResult: result.fixedResult,
-              fixableErrorCount: result.fixableErrorCount,
-              fixableWarningCount: result.fixableWarningCount,
-              executionErrors: result.executionErrors,
-            };
-            for (const warning of getIncompleteFixWarnings([stdinItem])) {
-              console.error(warning);
-            }
-            emitExecutionErrorsAndSetExitCode([stdinItem]);
-            if (isDev) {
-              for (const line of getFixDevMetrics([stdinItem])) {
-                console.error(line);
-              }
-            }
-            return;
-          } catch (e) {
-            const formatted = formatCoreError(e);
-            console.error(formatted.handled ? formatted.message : e);
-            process.exit(1);
-          }
-        }
-
-        if (!content.trim()) {
-          console.error("No content to lint");
-          process.exit(0);
-        }
-
-        try {
-          const result = lintMarkdown(content, rules, false);
-          const stdinItem = {
-            path: "(stdin)",
-            lintResult: result.lintResult,
-            fixableErrorCount: result.fixableErrorCount,
-            fixableWarningCount: result.fixableWarningCount,
-            executionErrors: result.executionErrors,
-          };
-          const { consoleMessage, errorCount, warningCount } = getReportData([
-            stdinItem,
-          ]);
-
-          console.log(consoleMessage);
-
-          const hasRuleFailures = emitExecutionErrorsAndSetExitCode([
-            stdinItem,
-          ]);
-
-          if (
-            errorCount > 0 ||
-            (!suppressWarnings && warningCount !== 0) ||
-            hasRuleFailures
-          ) {
-            setExitCode(1);
-            return;
-          }
-        } catch (e) {
-          const formatted = formatCoreError(e);
-          console.error(formatted.handled ? formatted.message : e);
-          process.exit(1);
-        }
-
-        const endTime = new Date().getTime();
-        console.log(`⌛️Done in ${endTime - startTime}ms.`);
+        runStdinLint({
+          content,
+          isDev,
+          isFixMode,
+          rules,
+          startTime,
+          suppressWarnings,
+        });
         return;
       }
 


### PR DESCRIPTION
Closes #125.

## Summary

- Add `runStdinLint()` to the CLI orchestration module.
- Keep stdin reading and option validation in the CLI entry.
- Preserve lint, fix, output, timing, and exit behavior.
- Add direct tests for the extracted stdin flow.

## Reason

The CLI entry contained the complete stdin workflow. Tests could only reach this behavior through a child process.

The new function provides a direct test interface. Existing process tests still protect the binary contract.

## Validation

- `npm test -- --runInBand __tests__/run-stdin-lint.spec.ts __tests__/stdin-fix.spec.ts __tests__/core-config-error-cli.spec.ts __tests__/threads-validation.spec.ts`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run test:package`