### PR TITLE
refactor: extract file lint flow

### DIFF
--- a/__tests__/run-file-lint.spec.ts
+++ b/__tests__/run-file-lint.spec.ts
@@ -1,0 +1,148 @@
+import {
+  batchLint,
+  resolveAdaptiveConcurrency,
+  runTasksWithLimit,
+} from "../src/utils/batch-lint";
+import { filterFilesByMaxSize } from "../src/utils/filter-by-max-size";
+import { loadMdFiles } from "../src/utils/load-md-files";
+import { safeWriteFile } from "../src/utils/safe-write-file";
+import { runFileLint } from "../src/cli/run-lint";
+import type { BatchLintItem } from "../src/types";
+
+jest.mock("../src/utils/batch-lint", () => ({
+  batchLint: jest.fn(),
+  resolveAdaptiveConcurrency: jest.fn(),
+  runTasksWithLimit: jest.fn(),
+}));
+jest.mock("../src/utils/filter-by-max-size", () => ({
+  filterFilesByMaxSize: jest.fn(),
+}));
+jest.mock("../src/utils/load-md-files", () => ({
+  loadMdFiles: jest.fn(),
+}));
+jest.mock("../src/utils/safe-write-file", () => ({
+  safeWriteFile: jest.fn(),
+}));
+
+const mockBatchLint = batchLint as jest.MockedFunction<typeof batchLint>;
+const mockFilterFilesByMaxSize = filterFilesByMaxSize as jest.MockedFunction<
+  typeof filterFilesByMaxSize
+>;
+const mockLoadMdFiles = loadMdFiles as jest.MockedFunction<typeof loadMdFiles>;
+const mockResolveAdaptiveConcurrency =
+  resolveAdaptiveConcurrency as jest.MockedFunction<
+    typeof resolveAdaptiveConcurrency
+  >;
+const mockRunTasksWithLimit = runTasksWithLimit as jest.MockedFunction<
+  typeof runTasksWithLimit
+>;
+const mockSafeWriteFile = safeWriteFile as jest.MockedFunction<
+  typeof safeWriteFile
+>;
+
+describe("runFileLint", () => {
+  const makeOptions = (
+    overrides: Partial<Parameters<typeof runFileLint>[0]> = {}
+  ): Parameters<typeof runFileLint>[0] => ({
+    excludeFiles: ["**/node_modules/**"],
+    extensions: [".md"],
+    files: ["*.md"],
+    isDev: false,
+    isFixMode: false,
+    maxFileSizeBytes: null,
+    rules: {},
+    startTime: 100,
+    suppressWarnings: false,
+    threadCount: 2,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockLoadMdFiles.mockResolvedValue(["document.md"]);
+    mockFilterFilesByMaxSize.mockImplementation(async (files) => files);
+    mockResolveAdaptiveConcurrency.mockResolvedValue({
+      concurrency: 1,
+      maxFileSize: null,
+      requestedConcurrency: 2,
+    });
+    mockBatchLint.mockResolvedValue({
+      allResults: [],
+      actionableResults: [],
+    });
+    mockRunTasksWithLimit.mockImplementation((async (
+      tasks: Array<() => Promise<unknown>>
+    ) => Promise.all(tasks.map((task) => task()))) as never);
+    mockSafeWriteFile.mockResolvedValue();
+    jest.spyOn(console, "log").mockImplementation();
+    jest.spyOn(Date, "now").mockReturnValue(125);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("returns before file discovery when no patterns are provided", async () => {
+    await runFileLint(makeOptions({ files: [] }));
+
+    expect(mockLoadMdFiles).not.toHaveBeenCalled();
+  });
+
+  test("exits successfully when file discovery returns no matches", async () => {
+    mockLoadMdFiles.mockResolvedValue([]);
+    const exit = jest.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as never);
+
+    await expect(runFileLint(makeOptions())).rejects.toThrow("process.exit");
+
+    expect(console.log).toHaveBeenCalledWith("🎉 No markdown files to lint 🎉");
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  test("filters files before concurrency and batch decisions", async () => {
+    mockLoadMdFiles.mockResolvedValue(["small.md", "large.md"]);
+    mockFilterFilesByMaxSize.mockResolvedValue(["small.md"]);
+
+    await runFileLint(makeOptions({ maxFileSizeBytes: 100 }));
+
+    expect(mockFilterFilesByMaxSize).toHaveBeenCalledWith(
+      ["small.md", "large.md"],
+      100
+    );
+    expect(mockResolveAdaptiveConcurrency).toHaveBeenCalledWith(2, [
+      "small.md",
+    ]);
+    expect(mockBatchLint).toHaveBeenCalledWith(1, ["small.md"], false, {});
+    expect(mockFilterFilesByMaxSize.mock.invocationCallOrder[0]).toBeLessThan(
+      mockResolveAdaptiveConcurrency.mock.invocationCallOrder[0]
+    );
+  });
+
+  test("writes actionable fixes and reports metrics for all results", async () => {
+    const cleanResult: BatchLintItem = {
+      path: "clean.md",
+      lintResult: [],
+      fixedResult: { result: "clean", notAppliedFixes: [] },
+    };
+    const actionableResult: BatchLintItem = {
+      path: "actionable.md",
+      lintResult: [],
+      fixedResult: { result: "fixed", notAppliedFixes: [] },
+    };
+    const allResults = [cleanResult, actionableResult];
+    const actionableResults = [actionableResult];
+    mockBatchLint.mockResolvedValue({ allResults, actionableResults });
+    const reportModule = require("../src/utils/report-incomplete-fixes");
+    const metrics = jest
+      .spyOn(reportModule, "getFixDevMetrics")
+      .mockReturnValue(["fix metrics"]);
+
+    await runFileLint(makeOptions({ isDev: true, isFixMode: true }));
+
+    expect(mockSafeWriteFile).toHaveBeenCalledTimes(1);
+    expect(mockSafeWriteFile).toHaveBeenCalledWith("actionable.md", "fixed");
+    expect(metrics).toHaveBeenCalledWith(allResults);
+    expect(console.log).toHaveBeenCalledWith("fix metrics");
+  });
+});

--- a/src/cli/run-lint.ts
+++ b/src/cli/run-lint.ts
@@ -1,9 +1,18 @@
 import * as process from "process";
 import { fixMarkdown, lintMarkdown } from "@lint-md/core";
 import type { LintMdRulesConfig } from "@lint-md/core";
-import type { BatchLintItem } from "../types";
+import type { BatchLintItem, ThreadCount } from "../types";
+import { safeWriteFile } from "../utils/safe-write-file";
+import {
+  batchLint,
+  resolveAdaptiveConcurrency,
+  runTasksWithLimit,
+} from "../utils/batch-lint";
+import { loadMdFiles } from "../utils/load-md-files";
+import { filterFilesByMaxSize } from "../utils/filter-by-max-size";
 import { formatCoreError } from "../utils/format-core-error";
 import { getReportData } from "../utils/get-report-data";
+import { getUnappliedFixesWarnings } from "../utils/report-unapplied-fixes";
 import {
   getFixDevMetrics,
   getIncompleteFixWarnings,
@@ -17,6 +26,19 @@ interface RunStdinLintOptions {
   rules: LintMdRulesConfig;
   startTime: number;
   suppressWarnings: boolean;
+}
+
+interface RunFileLintOptions {
+  excludeFiles: string[];
+  extensions: string[];
+  files: string[];
+  isDev: boolean;
+  isFixMode: boolean;
+  maxFileSizeBytes: number | null;
+  rules: LintMdRulesConfig;
+  startTime: number;
+  suppressWarnings: boolean;
+  threadCount: ThreadCount;
 }
 
 const setExitCode = (code: number): void => {
@@ -98,6 +120,117 @@ export const runStdinLint = ({
     ) {
       setExitCode(1);
       return;
+    }
+  } catch (error) {
+    const formatted = formatCoreError(error);
+    console.error(formatted.handled ? formatted.message : error);
+    process.exit(1);
+  }
+
+  const endTime = Date.now();
+  console.log(`⌛️Done in ${endTime - startTime}ms.`);
+};
+
+export const runFileLint = async ({
+  excludeFiles,
+  extensions,
+  files,
+  isDev,
+  isFixMode,
+  maxFileSizeBytes,
+  rules,
+  startTime,
+  suppressWarnings,
+  threadCount,
+}: RunFileLintOptions): Promise<void> => {
+  if (!files.length) {
+    return;
+  }
+
+  let mdFiles = await loadMdFiles(files, excludeFiles, extensions);
+
+  if (maxFileSizeBytes !== null) {
+    mdFiles = await filterFilesByMaxSize(mdFiles, maxFileSizeBytes);
+  }
+
+  if (!mdFiles.length) {
+    console.log("🎉 No markdown files to lint 🎉");
+    process.exit(0);
+    return;
+  }
+
+  const concurrencyDecision = await resolveAdaptiveConcurrency(
+    threadCount,
+    mdFiles
+  );
+  const effectiveThreads = concurrencyDecision.concurrency;
+
+  if (isDev && concurrencyDecision.maxFileSize !== null) {
+    const { maxFileSize, requestedConcurrency } = concurrencyDecision;
+    const adaptiveApplied = maxFileSize >= 1024 * 1024;
+    if (adaptiveApplied && effectiveThreads < requestedConcurrency) {
+      const maxMiB = (maxFileSize / (1024 * 1024)).toFixed(2);
+      console.log(
+        `[lint-md] Adaptive concurrency: requested auto, effective ${effectiveThreads}, max file ${maxMiB} MiB`
+      );
+    }
+  }
+
+  try {
+    const { allResults, actionableResults } = await batchLint(
+      effectiveThreads,
+      mdFiles,
+      isFixMode,
+      rules
+    );
+
+    if (!isFixMode) {
+      const { consoleMessage, errorCount, warningCount } =
+        getReportData(actionableResults);
+
+      console.log(consoleMessage);
+
+      const hasRuleFailures =
+        emitExecutionErrorsAndSetExitCode(actionableResults);
+
+      if (
+        errorCount > 0 ||
+        (!suppressWarnings && warningCount !== 0) ||
+        hasRuleFailures
+      ) {
+        setExitCode(1);
+        return;
+      }
+    } else {
+      await runTasksWithLimit(
+        actionableResults
+          .filter(({ fixedResult }) => fixedResult)
+          .map(
+            ({ path, fixedResult }) =>
+              () =>
+                safeWriteFile(path, fixedResult!.result)
+          ),
+        effectiveThreads
+      );
+
+      for (const warning of getIncompleteFixWarnings(actionableResults)) {
+        console.error(warning);
+      }
+      for (const warning of getUnappliedFixesWarnings(actionableResults)) {
+        console.error(warning);
+      }
+      const hasRuleFailures =
+        emitExecutionErrorsAndSetExitCode(actionableResults);
+
+      if (isDev) {
+        for (const line of getFixDevMetrics(allResults)) {
+          console.log(line);
+        }
+      }
+
+      if (hasRuleFailures) {
+        return;
+      }
     }
   } catch (error) {
     const formatted = formatCoreError(error);

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -8,29 +8,13 @@ const setExitCode = (code: number): void => {
 import { readFileSync } from "fs";
 import { Command } from "commander";
 import { version } from "../package.json";
-import { runStdinLint } from "./cli/run-lint";
-import { safeWriteFile } from "./utils/safe-write-file";
-import {
-  batchLint,
-  resolveAdaptiveConcurrency,
-  runTasksWithLimit,
-} from "./utils/batch-lint";
+import { runFileLint, runStdinLint } from "./cli/run-lint";
 import {
   getLintConfig,
   getMaxFileSizeOption,
   getThreadCount,
 } from "./utils/configure";
 import type { ThreadCount } from "./types";
-import { loadMdFiles } from "./utils/load-md-files";
-import { getReportData } from "./utils/get-report-data";
-import { filterFilesByMaxSize } from "./utils/filter-by-max-size";
-import { getUnappliedFixesWarnings } from "./utils/report-unapplied-fixes";
-import {
-  getFixDevMetrics,
-  getIncompleteFixWarnings,
-} from "./utils/report-incomplete-fixes";
-import { emitExecutionErrorsAndSetExitCode } from "./utils/report-execution-errors";
-import { formatCoreError } from "./utils/format-core-error";
 
 interface CLIOptions {
   fix?: boolean;
@@ -117,111 +101,18 @@ export const createProgram = (): Command => {
         return;
       }
 
-      if (!files.length) {
-        return;
-      }
-
-      let mdFiles = await loadMdFiles(files, excludeFiles, extensions);
-
-      // 过滤超大文件（stderr warning + 跳过），发生在 resolveAdaptiveConcurrency
-      // 之前，使 --threads auto 只基于剩余文件重算并发，两者互不感知。
-      if (maxFileSizeBytes !== null) {
-        mdFiles = await filterFilesByMaxSize(mdFiles, maxFileSizeBytes);
-      }
-
-      if (!mdFiles.length) {
-        console.log("🎉 No markdown files to lint 🎉");
-        process.exit(0);
-        return;
-      }
-
-      const concurrencyDecision = await resolveAdaptiveConcurrency(
+      await runFileLint({
+        excludeFiles,
+        extensions,
+        files,
+        isDev,
+        isFixMode,
+        maxFileSizeBytes,
+        rules,
+        startTime,
+        suppressWarnings,
         threadCount,
-        mdFiles
-      );
-      const effectiveThreads = concurrencyDecision.concurrency;
-
-      if (isDev && concurrencyDecision.maxFileSize !== null) {
-        const { maxFileSize, requestedConcurrency } = concurrencyDecision;
-        const adaptiveApplied = maxFileSize >= 1024 * 1024;
-        if (adaptiveApplied && effectiveThreads < requestedConcurrency) {
-          const maxMiB = (maxFileSize / (1024 * 1024)).toFixed(2);
-          console.log(
-            `[lint-md] Adaptive concurrency: requested auto, effective ${effectiveThreads}, max file ${maxMiB} MiB`
-          );
-        }
-      }
-
-      try {
-        const { allResults, actionableResults } = await batchLint(
-          effectiveThreads,
-          mdFiles,
-          isFixMode,
-          rules
-        );
-
-        if (!isFixMode) {
-          const { consoleMessage, errorCount, warningCount } =
-            getReportData(actionableResults);
-
-          console.log(consoleMessage);
-
-          const hasRuleFailures =
-            emitExecutionErrorsAndSetExitCode(actionableResults);
-
-          if (
-            errorCount > 0 ||
-            (!suppressWarnings && warningCount !== 0) ||
-            hasRuleFailures
-          ) {
-            setExitCode(1);
-            return;
-          }
-        } else {
-          await runTasksWithLimit(
-            actionableResults
-              .filter(({ fixedResult }) => fixedResult)
-              .map(
-                ({ path, fixedResult }) =>
-                  () =>
-                    safeWriteFile(path, fixedResult!.result)
-              ),
-            effectiveThreads
-          );
-
-          for (const warning of getIncompleteFixWarnings(actionableResults)) {
-            console.error(warning);
-          }
-          for (const warning of getUnappliedFixesWarnings(actionableResults)) {
-            console.error(warning);
-          }
-          const hasRuleFailures =
-            emitExecutionErrorsAndSetExitCode(actionableResults);
-
-          if (isDev) {
-            for (const line of getFixDevMetrics(allResults)) {
-              console.log(line);
-            }
-          }
-
-          // Rule execution errors (core #185) are hard failures: emitted above
-          // (after the fixes are written) and failed the CI run regardless of
-          // --suppress-warnings. emitExecutionErrorsAndSetExitCode already set
-          // process.exitCode = 1 so the written files and diagnostics flush.
-          // Early-return so we don't print a trailing "Done in …" on failure,
-          // matching the previous process.exit(1) behaviour.
-          if (hasRuleFailures) {
-            return;
-          }
-        }
-      } catch (e) {
-        const formatted = formatCoreError(e);
-        console.error(formatted.handled ? formatted.message : e);
-        process.exit(1);
-      }
-
-      const endTime = Date.now();
-      console.log(`⌛️Done in ${endTime - startTime}ms.`);
+      });
     });
 
   return program;


### PR DESCRIPTION
Closes #127.

## Summary

- Add `runFileLint()` to the CLI orchestration module.
- Move discovery, filtering, concurrency, workers, fixes, reports, and timing into it.
- Keep argument parsing, configuration, and validation in the CLI entry.
- Add direct tests for file flow boundaries.

## Behavior

- Maximum size filtering still runs before concurrency selection.
- Fix writes still use `actionableResults`.
- Development metrics still use `allResults`.
- Discovery and concurrency failures keep the top-level rejection path.

## Validation

- `npm test -- --runInBand __tests__/run-file-lint.spec.ts __tests__/run-stdin-lint.spec.ts __tests__/max-file-size.spec.ts __tests__/core-config-error-cli.spec.ts`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run test:package`