### PR TITLE
fix: write config errors to stderr

### DIFF
--- a/__tests__/configure-cli.spec.ts
+++ b/__tests__/configure-cli.spec.ts
@@ -1,0 +1,51 @@
+import { spawnSync } from "child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import * as path from "path";
+
+const TSX = path.resolve(__dirname, "../node_modules/tsx/dist/cli.mjs");
+const CLI = path.resolve(__dirname, "../src/lint-md.ts");
+
+describe("configuration diagnostics", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), "lint-md-config-cli-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const runStdinFix = (configPath: string) =>
+    spawnSync(
+      process.execPath,
+      [TSX, CLI, "--stdin", "--fix", "--config", configPath],
+      {
+        encoding: "utf8",
+        input: "# Hello\n",
+      }
+    );
+
+  test("writes a missing configuration error only to stderr", () => {
+    const result = runStdinFix(path.join(tmpDir, "missing.json"));
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Configure file");
+    expect(result.stderr).toContain("missing.json");
+  });
+
+  test("writes an invalid configuration error only to stderr", () => {
+    const configPath = path.join(tmpDir, "invalid.json");
+    writeFileSync(configPath, "{ invalid", "utf8");
+
+    const result = runStdinFix(configPath);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Configure file");
+    expect(result.stderr).toContain("invalid.json");
+    expect(result.stderr).toContain("is invalid");
+  });
+});

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -7,7 +7,7 @@ import { parseSize } from "./parse-size";
 
 export const getLintConfig = (configFilePath?: string): Required<CLIConfig> => {
   if (configFilePath && !fs.existsSync(configFilePath)) {
-    console.log(
+    console.error(
       chalk.red(`lint-md: Configure file '${configFilePath}' is not exist.`)
     );
     process.exit(1);
@@ -24,10 +24,10 @@ export const getLintConfig = (configFilePath?: string): Required<CLIConfig> => {
     try {
       config = JSON.parse(fs.readFileSync(configPath).toString());
     } catch (e) {
-      console.log(
+      console.error(
         chalk.red(`[lint-md] Configure file '${configPath}' is invalid.`)
       );
-      console.log(e);
+      console.error(e);
       process.exit(1);
     }
   }


### PR DESCRIPTION
Closes #107.

## Summary

- Write missing configuration errors to stderr.
- Write invalid configuration errors and parser details to stderr.
- Add CLI tests for missing and invalid configuration files.

## Impact

Stdin fix mode now keeps stdout empty when configuration loading fails. Redirected Markdown output no longer receives diagnostic text.

## Validation

- `npm test -- --runInBand __tests__/configure-cli.spec.ts`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run test:package`