### PR TITLE
fix: require a config path

### DIFF
--- a/__tests__/configure-cli.spec.ts
+++ b/__tests__/configure-cli.spec.ts
@@ -27,6 +27,17 @@ describe("configuration diagnostics", () => {
       }
     );
 
+  test("requires a path after --config", () => {
+    const result = spawnSync(process.execPath, [TSX, CLI, "--config"], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("--config <configure-file>");
+    expect(result.stderr).toContain("argument missing");
+  });
+
   test("writes a missing configuration error only to stderr", () => {
     const result = runStdinFix(path.join(tmpDir, "missing.json"));
 

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -38,7 +38,7 @@ export const createProgram = (): Command => {
     .usage("<lint-md> [files...]")
     .description("lint your markdown files")
     .option(
-      "-c, --config [configure-file]",
+      "-c, --config <configure-file>",
       "use the configure file, default .lintmdrc（使用配置文件，默认为 .lintmdrc）"
     )
     .option("-f, --fix", "fix the errors automatically（开启修复模式）")


### PR DESCRIPTION
Closes #106.

## Summary

- Make the `--config` option require a file path.
- Let Commander report a missing option value.
- Add a CLI regression test for `lint-md --config`.

## Impact

The CLI no longer treats the boolean value `true` as a configuration path. Missing values now produce a clear parser error.

## Validation

- `npm test -- --runInBand __tests__/configure-cli.spec.ts`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run test:package`