### PR TITLE
refactor(cli): make configuration validation side-effect free

### DIFF
--- a/__tests__/configure.spec.ts
+++ b/__tests__/configure.spec.ts
@@ -1,59 +1,112 @@
-import { cpus } from "os";
-import { getThreadCount } from "../src/utils/configure";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { cpus, tmpdir } from "os";
+import * as path from "path";
+import { CliError } from "../src/cli/cli-error";
+import {
+  getLintConfig,
+  getMaxFileSizeOption,
+  getThreadCount,
+} from "../src/utils/configure";
 
-describe("getThreadCount", () => {
-  let mockExit: jest.SpyInstance;
-  let mockError: jest.SpyInstance;
+const captureCliError = (run: () => unknown): CliError => {
+  try {
+    run();
+  } catch (error) {
+    expect(error).toBeInstanceOf(CliError);
+    return error as CliError;
+  }
+
+  throw new Error("Expected a CliError.");
+};
+
+describe("configuration validation", () => {
+  let tmpDir: string;
+  let consoleErrorSpy: jest.SpyInstance;
+  let exitSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    mockExit = jest.spyOn(process, "exit").mockImplementation(((
+    tmpDir = mkdtempSync(path.join(tmpdir(), "lint-md-config-"));
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    exitSpy = jest.spyOn(process, "exit").mockImplementation(((
       code?: number
     ) => {
       throw new Error(`process.exit: ${code}`);
     }) as never);
-    mockError = jest.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
-    mockExit.mockRestore();
-    mockError.mockRestore();
+    consoleErrorSpy.mockRestore();
+    exitSpy.mockRestore();
+    rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test("undefined → cpus().length", () => {
+  test("throws a structured error for a missing configuration file", () => {
+    const configPath = path.join(tmpDir, "missing.json");
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error).toMatchObject({
+      code: "CONFIG_NOT_FOUND",
+      message: `lint-md: Configure file '${configPath}' is not exist.`,
+    });
+    expect(error.detail).toBeUndefined();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  test("keeps the JSON parse error for an invalid configuration file", () => {
+    const configPath = path.join(tmpDir, "invalid.json");
+    writeFileSync(configPath, "{ invalid", "utf8");
+
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error).toMatchObject({
+      code: "CONFIG_INVALID",
+      message: `[lint-md] Configure file '${configPath}' is invalid.`,
+    });
+    expect(error.detail).toBeInstanceOf(SyntaxError);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  test("uses the CPU count when threads are not specified", () => {
     expect(getThreadCount(undefined)).toBe(cpus().length);
-  });
-
-  test("false → cpus().length", () => {
     expect(getThreadCount(false)).toBe(cpus().length);
-  });
-
-  test("true (--threads 无值) → cpus().length", () => {
     expect(getThreadCount(true)).toBe(cpus().length);
   });
 
-  test("number 2 → 2", () => {
+  test("accepts positive integer thread counts", () => {
     expect(getThreadCount(2)).toBe(2);
-  });
-
-  test('string "1" → 1', () => {
     expect(getThreadCount("1")).toBe(1);
-  });
-
-  test('string "4" → 4', () => {
     expect(getThreadCount("4")).toBe(4);
   });
 
+  test('accepts "auto" as the thread count', () => {
+    expect(getThreadCount("auto")).toBe("auto");
+  });
+
   test.each([0, -1, "0", "-1", "abc", "1.5", "0x10", "1e3"])(
-    "%s → exit 1 + stderr",
-    (value) => {
-      expect(() => getThreadCount(value)).toThrow("process.exit: 1");
-      expect(mockError).toHaveBeenCalledWith(
-        expect.stringContaining("--threads must be a positive integer")
-      );
+    "throws a structured error for invalid threads: %p",
+    (threadCount) => {
+      const error = captureCliError(() => getThreadCount(threadCount));
+
+      expect(error).toMatchObject({
+        code: "INVALID_THREADS",
+        message: "[lint-md] --threads must be a positive integer.",
+      });
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
     }
   );
 
-  test('"auto" → "auto"', () => {
-    expect(getThreadCount("auto")).toBe("auto");
+  test("throws a structured error for an invalid maximum file size", () => {
+    const error = captureCliError(() => getMaxFileSizeOption("1.5mb"));
+
+    expect(error).toMatchObject({
+      code: "INVALID_MAX_FILE_SIZE",
+      message:
+        "[lint-md] --max-file-size must be a valid size (e.g. 5mb, 500kb, 1gb).",
+    });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/cli-error.ts
+++ b/src/cli/cli-error.ts
@@ -1,0 +1,28 @@
+import chalk from "chalk";
+
+export type CliErrorCode =
+  | "CONFIG_NOT_FOUND"
+  | "CONFIG_INVALID"
+  | "INVALID_THREADS"
+  | "INVALID_MAX_FILE_SIZE";
+
+export class CliError extends Error {
+  constructor(
+    readonly code: CliErrorCode,
+    message: string,
+    readonly detail?: unknown
+  ) {
+    super(message);
+    this.name = "CliError";
+  }
+}
+
+export const formatCliError = (error: CliError): unknown[] => {
+  const output: unknown[] = [chalk.red(error.message)];
+
+  if (error.detail !== undefined) {
+    output.push(error.detail);
+  }
+
+  return output;
+};

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -8,6 +8,7 @@ const setExitCode = (code: number): void => {
 import { readFileSync } from "fs";
 import { Command } from "commander";
 import { version } from "../package.json";
+import { CliError, formatCliError } from "./cli/cli-error";
 import { runFileLint, runStdinLint } from "./cli/run-lint";
 import {
   getLintConfig,
@@ -81,13 +82,10 @@ export const createProgram = (): Command => {
 
       const { rules, excludeFiles, extensions } = getLintConfig(config);
 
-      // --threads 参数校验，所有分支共用
       const threadCount: ThreadCount = getThreadCount(threads);
 
-      // --max-file-size 校验（未传 = null = 不过滤），失败早退，与 --threads 一致
       const maxFileSizeBytes = getMaxFileSizeOption(maxFileSize);
 
-      // Handle stdin mode
       if (stdin) {
         const content = readFileSync(process.stdin.fd, "utf8");
         runStdinLint({
@@ -130,7 +128,14 @@ export const main = async (argv: string[] = process.argv): Promise<void> => {
 
 export const runCli = (argv: string[] = process.argv): void => {
   void main(argv).catch((error) => {
-    console.error(error);
+    if (error instanceof CliError) {
+      for (const output of formatCliError(error)) {
+        console.error(output);
+      }
+    } else {
+      console.error(error);
+    }
+
     setExitCode(1);
   });
 };

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -1,34 +1,33 @@
 import * as fs from "fs";
 import { availableParallelism } from "os";
 import * as path from "path";
-import chalk from "chalk";
+import { CliError } from "../cli/cli-error";
 import type { CLIConfig, ThreadCount } from "../types";
 import { parseSize } from "./parse-size";
 
 export const getLintConfig = (configFilePath?: string): Required<CLIConfig> => {
   if (configFilePath && !fs.existsSync(configFilePath)) {
-    console.error(
-      chalk.red(`lint-md: Configure file '${configFilePath}' is not exist.`)
+    throw new CliError(
+      "CONFIG_NOT_FOUND",
+      `lint-md: Configure file '${configFilePath}' is not exist.`
     );
-    process.exit(1);
   }
 
   let config: CLIConfig;
 
   const configPath = path.resolve(configFilePath || "./.lintmdrc");
 
-  // 如果不存在文件直接返回空对象
   if (!fs.existsSync(configPath)) {
     config = {};
   } else {
     try {
       config = JSON.parse(fs.readFileSync(configPath).toString());
-    } catch (e) {
-      console.error(
-        chalk.red(`[lint-md] Configure file '${configPath}' is invalid.`)
+    } catch (error) {
+      throw new CliError(
+        "CONFIG_INVALID",
+        `[lint-md] Configure file '${configPath}' is invalid.`,
+        error
       );
-      console.error(e);
-      process.exit(1);
     }
   }
 
@@ -47,31 +46,29 @@ export const getThreadCount = (
     return "auto";
   }
 
-  // 只接受 number 或 string，其他（undefined / boolean）视为未指定
   if (typeof threadCount !== "number" && typeof threadCount !== "string") {
     return availableParallelism();
   }
 
-  // 字符串必须是十进制正整数（拒绝 0x10、1e3、010 等）
   if (typeof threadCount === "string" && !/^[1-9]\d*$/.test(threadCount)) {
-    console.error(chalk.red("[lint-md] --threads must be a positive integer."));
-    process.exit(1);
+    throw new CliError(
+      "INVALID_THREADS",
+      "[lint-md] --threads must be a positive integer."
+    );
   }
 
   const num = Number(threadCount);
 
   if (!Number.isInteger(num) || num <= 0) {
-    console.error(chalk.red("[lint-md] --threads must be a positive integer."));
-    process.exit(1);
+    throw new CliError(
+      "INVALID_THREADS",
+      "[lint-md] --threads must be a positive integer."
+    );
   }
 
   return num;
 };
 
-// Resolves the optional --max-file-size CLI flag into a byte limit.
-// Returns null when the flag is not provided (no filtering, backward
-// compatible). Invalid input exits 1 with a stderr message, matching the
-// --threads validation style.
 export const getMaxFileSizeOption = (
   maxFileSize?: string | boolean
 ): number | null => {
@@ -82,11 +79,9 @@ export const getMaxFileSizeOption = (
   try {
     return parseSize(maxFileSize);
   } catch {
-    console.error(
-      chalk.red(
-        "[lint-md] --max-file-size must be a valid size (e.g. 5mb, 500kb, 1gb)."
-      )
+    throw new CliError(
+      "INVALID_MAX_FILE_SIZE",
+      "[lint-md] --max-file-size must be a valid size (e.g. 5mb, 500kb, 1gb)."
     );
-    process.exit(1);
   }
 };


### PR DESCRIPTION
## Summary

- Add structured CLI errors for configuration validation.
- Make configuration utilities throw errors without process side effects.
- Format validation errors at the CLI boundary.
- Preserve current messages, stderr output, and exit status.

Part of #131.

## Behavior

Commander still owns parser errors. Invalid JSON still includes the original parse error.

## Validation

- npm run lint
- npm test -- --runInBand
- npm run test:package

All 167 tests pass.