### PR TITLE
refactor(cli): centralize lint failure decision

### DIFF
--- a/__tests__/should-fail-lint.spec.ts
+++ b/__tests__/should-fail-lint.spec.ts
@@ -1,0 +1,146 @@
+import { shouldFailLint } from "../src/cli/should-fail-lint";
+
+interface FailureCase {
+  errorCount: number;
+  warningCount: number;
+  hasRuleFailures: boolean;
+  suppressWarnings: boolean;
+  expected: boolean;
+}
+
+const failureCases: FailureCase[] = [
+  {
+    errorCount: 0,
+    warningCount: 0,
+    hasRuleFailures: false,
+    suppressWarnings: false,
+    expected: false,
+  },
+  {
+    errorCount: 0,
+    warningCount: 0,
+    hasRuleFailures: true,
+    suppressWarnings: false,
+    expected: true,
+  },
+  {
+    errorCount: 0,
+    warningCount: 1,
+    hasRuleFailures: false,
+    suppressWarnings: false,
+    expected: true,
+  },
+  {
+    errorCount: 0,
+    warningCount: 1,
+    hasRuleFailures: true,
+    suppressWarnings: false,
+    expected: true,
+  },
+  {
+    errorCount: 1,
+    warningCount: 0,
+    hasRuleFailures: false,
+    suppressWarnings: false,
+    expected: true,
+  },
+  {
+    errorCount: 1,
+    warningCount: 0,
+    hasRuleFailures: true,
+    suppressWarnings: false,
+    expected: true,
+  },
+  {
+    errorCount: 1,
+    warningCount: 1,
+    hasRuleFailures: false,
+    suppressWarnings: false,
+    expected: true,
+  },
+  {
+    errorCount: 1,
+    warningCount: 1,
+    hasRuleFailures: true,
+    suppressWarnings: false,
+    expected: true,
+  },
+  {
+    errorCount: 0,
+    warningCount: 0,
+    hasRuleFailures: false,
+    suppressWarnings: true,
+    expected: false,
+  },
+  {
+    errorCount: 0,
+    warningCount: 0,
+    hasRuleFailures: true,
+    suppressWarnings: true,
+    expected: true,
+  },
+  {
+    errorCount: 0,
+    warningCount: 1,
+    hasRuleFailures: false,
+    suppressWarnings: true,
+    expected: false,
+  },
+  {
+    errorCount: 0,
+    warningCount: 1,
+    hasRuleFailures: true,
+    suppressWarnings: true,
+    expected: true,
+  },
+  {
+    errorCount: 1,
+    warningCount: 0,
+    hasRuleFailures: false,
+    suppressWarnings: true,
+    expected: true,
+  },
+  {
+    errorCount: 1,
+    warningCount: 0,
+    hasRuleFailures: true,
+    suppressWarnings: true,
+    expected: true,
+  },
+  {
+    errorCount: 1,
+    warningCount: 1,
+    hasRuleFailures: false,
+    suppressWarnings: true,
+    expected: true,
+  },
+  {
+    errorCount: 1,
+    warningCount: 1,
+    hasRuleFailures: true,
+    suppressWarnings: true,
+    expected: true,
+  },
+];
+
+describe("shouldFailLint", () => {
+  test.each(failureCases)(
+    "returns $expected for errors=$errorCount warnings=$warningCount rule failures=$hasRuleFailures suppression=$suppressWarnings",
+    ({
+      errorCount,
+      expected,
+      hasRuleFailures,
+      suppressWarnings,
+      warningCount,
+    }) => {
+      expect(
+        shouldFailLint({
+          errorCount,
+          hasRuleFailures,
+          suppressWarnings,
+          warningCount,
+        })
+      ).toBe(expected);
+    }
+  );
+});

--- a/src/cli/run-lint.ts
+++ b/src/cli/run-lint.ts
@@ -18,6 +18,7 @@ import {
   getIncompleteFixWarnings,
 } from "../utils/report-incomplete-fixes";
 import { emitExecutionErrorsAndSetExitCode } from "../utils/report-execution-errors";
+import { shouldFailLint } from "./should-fail-lint";
 
 interface RunStdinLintOptions {
   content: string;
@@ -114,9 +115,12 @@ export const runStdinLint = ({
     const hasRuleFailures = emitExecutionErrorsAndSetExitCode([stdinItem]);
 
     if (
-      errorCount > 0 ||
-      (!suppressWarnings && warningCount !== 0) ||
-      hasRuleFailures
+      shouldFailLint({
+        errorCount,
+        hasRuleFailures,
+        suppressWarnings,
+        warningCount,
+      })
     ) {
       setExitCode(1);
       return;
@@ -194,9 +198,12 @@ export const runFileLint = async ({
         emitExecutionErrorsAndSetExitCode(actionableResults);
 
       if (
-        errorCount > 0 ||
-        (!suppressWarnings && warningCount !== 0) ||
-        hasRuleFailures
+        shouldFailLint({
+          errorCount,
+          hasRuleFailures,
+          suppressWarnings,
+          warningCount,
+        })
       ) {
         setExitCode(1);
         return;

--- a/src/cli/should-fail-lint.ts
+++ b/src/cli/should-fail-lint.ts
@@ -1,0 +1,14 @@
+export interface LintFailureInput {
+  errorCount: number;
+  warningCount: number;
+  hasRuleFailures: boolean;
+  suppressWarnings: boolean;
+}
+
+export const shouldFailLint = ({
+  errorCount,
+  hasRuleFailures,
+  suppressWarnings,
+  warningCount,
+}: LintFailureInput): boolean =>
+  errorCount > 0 || hasRuleFailures || (!suppressWarnings && warningCount > 0);


### PR DESCRIPTION
## Summary

- Add the pure shouldFailLint function.
- Use one failure policy for stdin and file lint.
- Keep errors and rule failures fatal.
- Suppress warnings only when the option is active.

Part of #131.

## Tests

The policy test covers all 16 input combinations. It varies errors, warnings, rule failures, and warning suppression.

## Validation

- npm run lint
- npm test -- --runInBand
- npm run test:package

All 183 tests pass.