### PR TITLE
refactor(cli): centralize diagnostics and exit handling

### DIFF
--- a/__tests__/cli.spec.ts
+++ b/__tests__/cli.spec.ts
@@ -10,6 +10,7 @@ describe("cli tests", () => {
     process.argv = originalArgv;
     process.exitCode = originalExitCode;
     jest.dontMock("../src/utils/load-md-files");
+    jest.dontMock("../src/cli/run-lint");
     jest.restoreAllMocks();
   });
 
@@ -60,6 +61,7 @@ describe("cli tests", () => {
       .mockImplementation((() => undefined) as never);
     jest.spyOn(console, "log").mockImplementation();
     const { main } = require("../src/lint-md");
+    process.exitCode = undefined;
 
     let settled = false;
     const result = main(["node", "lint-md", "fixture.md"]).then(() => {
@@ -74,7 +76,23 @@ describe("cli tests", () => {
 
     expect(settled).toBe(true);
     expect(loadMdFiles).toHaveBeenCalledTimes(1);
-    expect(mockExit).toHaveBeenCalledWith(0);
+    expect(mockExit).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(0);
+  });
+
+  test("main applies the lint outcome at the CLI boundary", async () => {
+    const runFileLint = jest.fn().mockResolvedValue({ exitCode: 1 });
+    jest.doMock("../src/cli/run-lint", () => ({
+      runFileLint,
+      runStdinLint: jest.fn(),
+    }));
+    const { main } = require("../src/lint-md");
+    process.exitCode = undefined;
+
+    await main(["node", "lint-md", "fixture.md"]);
+
+    expect(runFileLint).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(1);
   });
 
   test("runCli handles rejected actions", async () => {

--- a/__tests__/report-execution-errors.spec.ts
+++ b/__tests__/report-execution-errors.spec.ts
@@ -1,8 +1,6 @@
 import {
-  emitExecutionErrorsAndSetExitCode,
   getExecutionErrorWarnings,
   hasExecutionErrors,
-  reportExecutionErrors,
 } from "../src/utils/report-execution-errors";
 import type { RuleExecutionError } from "@lint-md/core";
 import type { BatchLintItem } from "../src/types";
@@ -115,116 +113,28 @@ describe("report-execution-errors", () => {
     test("returns no warnings when no item has execution errors", () => {
       expect(getExecutionErrorWarnings([makeItem("a.md")])).toEqual([]);
     });
-  });
 
-  describe("reportExecutionErrors", () => {
-    const makeStream = () => {
-      const chunks: string[] = [];
-      const stream = {
-        write: (chunk: string) => {
-          chunks.push(chunk);
-          return true;
-        },
-      } as unknown as NodeJS.WritableStream;
-      return { stream, chunks };
-    };
+    test("does not write output or change the process exit code", () => {
+      const originalExitCode = process.exitCode;
+      const stderr = jest
+        .spyOn(process.stderr, "write")
+        .mockImplementation(() => true);
+      process.exitCode = undefined;
 
-    test("writes one line per error to the given stream and returns true", () => {
-      const { stream, chunks } = makeStream();
-      const ok = reportExecutionErrors(
-        [
+      try {
+        const lines = getExecutionErrorWarnings([
           makeItem("a.md", [
             { ruleName: "r", message: "boom", round: 1, phase: "fix" },
           ]),
-        ],
-        stream
-      );
+        ]);
 
-      expect(ok).toBe(true);
-      expect(chunks).toEqual([
-        "[lint-md] a.md: r failed in fix (round 1): boom\n",
-      ]);
-    });
-
-    test("returns false and writes nothing when there are no errors", () => {
-      const { stream, chunks } = makeStream();
-      const ok = reportExecutionErrors([makeItem("a.md")], stream);
-
-      expect(ok).toBe(false);
-      expect(chunks).toEqual([]);
-    });
-
-    test("does not deduplicate errors from the same rule across rounds", () => {
-      const { stream, chunks } = makeStream();
-      reportExecutionErrors(
-        [
-          makeItem("d.md", [
-            { ruleName: "r", message: "x", round: 1, phase: "fix" },
-            { ruleName: "r", message: "x", round: 2, phase: "fix" },
-          ]),
-        ],
-        stream
-      );
-
-      expect(chunks).toEqual([
-        "[lint-md] d.md: r failed in fix (round 1): x\n",
-        "[lint-md] d.md: r failed in fix (round 2): x\n",
-      ]);
-    });
-  });
-
-  describe("emitExecutionErrorsAndSetExitCode", () => {
-    const baseError = {
-      ruleName: "boom",
-      message: "rule threw",
-      round: 1,
-      phase: "fix" as const,
-    };
-
-    let exitCodeBefore: number | undefined;
-    let stderrSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      exitCodeBefore = process.exitCode as number | undefined;
-      process.exitCode = undefined;
-      stderrSpy = jest
-        .spyOn(process.stderr, "write")
-        .mockImplementation(() => true);
-    });
-
-    afterEach(() => {
-      stderrSpy.mockRestore();
-      process.exitCode = exitCodeBefore;
-    });
-
-    test("writes diagnostics to stderr and sets process.exitCode = 1", () => {
-      const reported = emitExecutionErrorsAndSetExitCode([
-        makeItem("a.md", [baseError]),
-      ]);
-
-      expect(reported).toBe(true);
-      expect(process.exitCode).toBe(1);
-      expect(stderrSpy).toHaveBeenCalledWith(
-        expect.stringContaining("[lint-md] a.md: boom failed in fix")
-      );
-    });
-
-    test("does not set exitCode and returns false when there are no errors", () => {
-      const reported = emitExecutionErrorsAndSetExitCode([makeItem("a.md")]);
-
-      expect(reported).toBe(false);
-      expect(process.exitCode).toBeUndefined();
-      expect(stderrSpy).not.toHaveBeenCalled();
-    });
-
-    test("sets exitCode = 1 even when it is already 1 (idempotent)", () => {
-      process.exitCode = 1;
-      const reported = emitExecutionErrorsAndSetExitCode([
-        makeItem("a.md", [baseError]),
-      ]);
-
-      expect(reported).toBe(true);
-      expect(process.exitCode).toBe(1);
+        expect(lines).toHaveLength(1);
+        expect(stderr).not.toHaveBeenCalled();
+        expect(process.exitCode).toBeUndefined();
+      } finally {
+        stderr.mockRestore();
+        process.exitCode = originalExitCode;
+      }
     });
   });
 });

--- a/__tests__/run-file-lint.spec.ts
+++ b/__tests__/run-file-lint.spec.ts
@@ -41,6 +41,8 @@ const mockSafeWriteFile = safeWriteFile as jest.MockedFunction<
 >;
 
 describe("runFileLint", () => {
+  const originalExitCode = process.exitCode;
+
   const makeOptions = (
     overrides: Partial<Parameters<typeof runFileLint>[0]> = {}
   ): Parameters<typeof runFileLint>[0] => ({
@@ -59,6 +61,7 @@ describe("runFileLint", () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    process.exitCode = undefined;
     mockLoadMdFiles.mockResolvedValue(["document.md"]);
     mockFilterFilesByMaxSize.mockImplementation(async (files) => files);
     mockResolveAdaptiveConcurrency.mockResolvedValue({
@@ -79,6 +82,7 @@ describe("runFileLint", () => {
   });
 
   afterEach(() => {
+    process.exitCode = originalExitCode;
     jest.restoreAllMocks();
   });
 
@@ -88,16 +92,17 @@ describe("runFileLint", () => {
     expect(mockLoadMdFiles).not.toHaveBeenCalled();
   });
 
-  test("exits successfully when file discovery returns no matches", async () => {
+  test("returns success when file discovery returns no matches", async () => {
     mockLoadMdFiles.mockResolvedValue([]);
     const exit = jest.spyOn(process, "exit").mockImplementation((() => {
       throw new Error("process.exit");
     }) as never);
 
-    await expect(runFileLint(makeOptions())).rejects.toThrow("process.exit");
+    const outcome = await runFileLint(makeOptions());
 
     expect(console.log).toHaveBeenCalledWith("🎉 No markdown files to lint 🎉");
-    expect(exit).toHaveBeenCalledWith(0);
+    expect(exit).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ exitCode: 0 });
   });
 
   test("filters files before concurrency and batch decisions", async () => {
@@ -117,6 +122,53 @@ describe("runFileLint", () => {
     expect(mockFilterFilesByMaxSize.mock.invocationCallOrder[0]).toBeLessThan(
       mockResolveAdaptiveConcurrency.mock.invocationCallOrder[0]
     );
+  });
+
+  test("returns success and reports timing after a clean lint", async () => {
+    const outcome = await runFileLint(makeOptions());
+
+    expect(console.log).toHaveBeenCalledWith("");
+    expect(console.log).toHaveBeenCalledWith("⌛️Done in 25ms.");
+    expect(outcome).toEqual({ exitCode: 0 });
+  });
+
+  test("reports rule failures to stderr and returns failure without timing", async () => {
+    const failedResult: BatchLintItem = {
+      path: "failed.md",
+      lintResult: [],
+      executionErrors: [
+        {
+          ruleName: "broken-rule",
+          message: "rule threw",
+          round: 1,
+          phase: "selector",
+        },
+      ],
+    };
+    mockBatchLint.mockResolvedValue({
+      allResults: [failedResult],
+      actionableResults: [failedResult],
+    });
+    const stderr = jest.spyOn(console, "error").mockImplementation();
+    const exit = jest.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as never);
+
+    const outcome = await runFileLint(makeOptions({ suppressWarnings: true }));
+
+    expect(console.log).toHaveBeenCalledWith("");
+    expect(stderr).toHaveBeenCalledWith(
+      "[lint-md] failed.md: broken-rule failed in selector (round 1): rule threw"
+    );
+    expect((console.log as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      stderr.mock.invocationCallOrder[0]
+    );
+    expect(console.log).not.toHaveBeenCalledWith(
+      expect.stringContaining("Done in")
+    );
+    expect(exit).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+    expect(outcome).toEqual({ exitCode: 1 });
   });
 
   test("writes actionable fixes and reports metrics for all results", async () => {

--- a/__tests__/run-stdin-lint.spec.ts
+++ b/__tests__/run-stdin-lint.spec.ts
@@ -1,3 +1,4 @@
+import * as lintCore from "@lint-md/core";
 import { runStdinLint } from "../src/cli/run-lint";
 
 describe("runStdinLint", () => {
@@ -13,7 +14,7 @@ describe("runStdinLint", () => {
       .spyOn(process.stdout, "write")
       .mockImplementation((() => true) as never);
 
-    runStdinLint({
+    const outcome = runStdinLint({
       content: "   \n\n",
       isDev: false,
       isFixMode: true,
@@ -23,34 +24,34 @@ describe("runStdinLint", () => {
     });
 
     expect(write).toHaveBeenCalledWith("   \n\n");
+    expect(outcome).toEqual({ exitCode: 0 });
   });
 
-  test("exits successfully when lint input has no content", () => {
+  test("returns success when lint input has no content", () => {
     const error = jest.spyOn(console, "error").mockImplementation();
     const exit = jest.spyOn(process, "exit").mockImplementation((() => {
       throw new Error("process.exit");
     }) as never);
 
-    expect(() =>
-      runStdinLint({
-        content: " \n",
-        isDev: false,
-        isFixMode: false,
-        rules: {},
-        startTime: 0,
-        suppressWarnings: false,
-      })
-    ).toThrow("process.exit");
+    const outcome = runStdinLint({
+      content: " \n",
+      isDev: false,
+      isFixMode: false,
+      rules: {},
+      startTime: 0,
+      suppressWarnings: false,
+    });
 
     expect(error).toHaveBeenCalledWith("No content to lint");
-    expect(exit).toHaveBeenCalledWith(0);
+    expect(exit).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ exitCode: 0 });
   });
 
   test("reports timing after a clean lint", () => {
     const log = jest.spyOn(console, "log").mockImplementation();
     jest.spyOn(Date, "now").mockReturnValue(125);
 
-    runStdinLint({
+    const outcome = runStdinLint({
       content: "# Hello\n",
       isDev: false,
       isFixMode: false,
@@ -61,5 +62,95 @@ describe("runStdinLint", () => {
 
     expect(log).toHaveBeenCalledWith("");
     expect(log).toHaveBeenCalledWith("⌛️Done in 25ms.");
+    expect(outcome).toEqual({ exitCode: 0 });
+  });
+
+  test("reports rule failures to stderr and returns failure without timing", () => {
+    jest.spyOn(lintCore, "lintMarkdown").mockReturnValue({
+      lintResult: [],
+      fixedResult: null,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0,
+      executionErrors: [
+        {
+          ruleName: "broken-rule",
+          message: "rule threw",
+          round: 1,
+          phase: "create",
+        },
+      ],
+    } as any);
+    const stdout = jest.spyOn(console, "log").mockImplementation();
+    const stderr = jest.spyOn(console, "error").mockImplementation();
+    const exit = jest.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as never);
+    process.exitCode = undefined;
+
+    const outcome = runStdinLint({
+      content: "# Hello\n",
+      isDev: false,
+      isFixMode: false,
+      rules: {},
+      startTime: 100,
+      suppressWarnings: true,
+    });
+
+    expect(stdout).toHaveBeenCalledWith("");
+    expect(stderr).toHaveBeenCalledWith(
+      "[lint-md] (stdin): broken-rule failed in create (round 1): rule threw"
+    );
+    expect(stdout.mock.invocationCallOrder[0]).toBeLessThan(
+      stderr.mock.invocationCallOrder[0]
+    );
+    expect(stdout).not.toHaveBeenCalledWith(expect.stringContaining("Done in"));
+    expect(exit).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+    expect(outcome).toEqual({ exitCode: 1 });
+  });
+
+  test("keeps fix output pipe-safe when a rule fails", () => {
+    jest.spyOn(lintCore, "fixMarkdown").mockReturnValue({
+      lintResult: [],
+      fixedResult: null,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0,
+      executionErrors: [
+        {
+          ruleName: "broken-rule",
+          message: "rule threw",
+          round: 1,
+          phase: "fix",
+        },
+      ],
+    } as any);
+    const stdout = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation((() => true) as never);
+    const stderr = jest.spyOn(console, "error").mockImplementation();
+    const exit = jest.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as never);
+    process.exitCode = undefined;
+
+    const outcome = runStdinLint({
+      content: "# Original\n",
+      isDev: false,
+      isFixMode: true,
+      rules: {},
+      startTime: 100,
+      suppressWarnings: true,
+    });
+
+    expect(stdout).toHaveBeenCalledWith("# Original\n");
+    expect(stderr).toHaveBeenCalledWith(
+      "[lint-md] (stdin): broken-rule failed in fix (round 1): rule threw"
+    );
+    expect(stdout.mock.invocationCallOrder[0]).toBeLessThan(
+      stderr.mock.invocationCallOrder[0]
+    );
+    expect(exit).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+    expect(outcome).toEqual({ exitCode: 1 });
   });
 });

--- a/src/cli/exit-outcome.ts
+++ b/src/cli/exit-outcome.ts
@@ -1,0 +1,8 @@
+export type CliExitCode = 0 | 1;
+
+export interface CliExitOutcome {
+  readonly exitCode: CliExitCode;
+}
+
+export const SUCCESS_EXIT: CliExitOutcome = { exitCode: 0 };
+export const FAILURE_EXIT: CliExitOutcome = { exitCode: 1 };

--- a/src/cli/run-lint.ts
+++ b/src/cli/run-lint.ts
@@ -17,7 +17,12 @@ import {
   getFixDevMetrics,
   getIncompleteFixWarnings,
 } from "../utils/report-incomplete-fixes";
-import { emitExecutionErrorsAndSetExitCode } from "../utils/report-execution-errors";
+import { getExecutionErrorWarnings } from "../utils/report-execution-errors";
+import {
+  FAILURE_EXIT,
+  SUCCESS_EXIT,
+  type CliExitOutcome,
+} from "./exit-outcome";
 import { shouldFailLint } from "./should-fail-lint";
 
 interface RunStdinLintOptions {
@@ -42,10 +47,6 @@ interface RunFileLintOptions {
   threadCount: ThreadCount;
 }
 
-const setExitCode = (code: number): void => {
-  (globalThis as { process?: NodeJS.Process }).process!.exitCode = code;
-};
-
 export const runStdinLint = ({
   content,
   isDev,
@@ -53,15 +54,15 @@ export const runStdinLint = ({
   rules,
   startTime,
   suppressWarnings,
-}: RunStdinLintOptions): void => {
+}: RunStdinLintOptions): CliExitOutcome => {
   if (isFixMode) {
     if (content.length === 0) {
-      return;
+      return SUCCESS_EXIT;
     }
 
     if (!content.trim()) {
       process.stdout.write(content);
-      return;
+      return SUCCESS_EXIT;
     }
 
     try {
@@ -78,23 +79,26 @@ export const runStdinLint = ({
       for (const warning of getIncompleteFixWarnings([stdinItem])) {
         console.error(warning);
       }
-      emitExecutionErrorsAndSetExitCode([stdinItem]);
+      const executionErrorWarnings = getExecutionErrorWarnings([stdinItem]);
+      for (const warning of executionErrorWarnings) {
+        console.error(warning);
+      }
       if (isDev) {
         for (const line of getFixDevMetrics([stdinItem])) {
           console.error(line);
         }
       }
-      return;
+      return executionErrorWarnings.length > 0 ? FAILURE_EXIT : SUCCESS_EXIT;
     } catch (error) {
       const formatted = formatCoreError(error);
       console.error(formatted.handled ? formatted.message : error);
-      process.exit(1);
+      return FAILURE_EXIT;
     }
   }
 
   if (!content.trim()) {
     console.error("No content to lint");
-    process.exit(0);
+    return SUCCESS_EXIT;
   }
 
   try {
@@ -112,7 +116,11 @@ export const runStdinLint = ({
 
     console.log(consoleMessage);
 
-    const hasRuleFailures = emitExecutionErrorsAndSetExitCode([stdinItem]);
+    const executionErrorWarnings = getExecutionErrorWarnings([stdinItem]);
+    for (const warning of executionErrorWarnings) {
+      console.error(warning);
+    }
+    const hasRuleFailures = executionErrorWarnings.length > 0;
 
     if (
       shouldFailLint({
@@ -122,17 +130,17 @@ export const runStdinLint = ({
         warningCount,
       })
     ) {
-      setExitCode(1);
-      return;
+      return FAILURE_EXIT;
     }
   } catch (error) {
     const formatted = formatCoreError(error);
     console.error(formatted.handled ? formatted.message : error);
-    process.exit(1);
+    return FAILURE_EXIT;
   }
 
   const endTime = Date.now();
   console.log(`⌛️Done in ${endTime - startTime}ms.`);
+  return SUCCESS_EXIT;
 };
 
 export const runFileLint = async ({
@@ -146,9 +154,9 @@ export const runFileLint = async ({
   startTime,
   suppressWarnings,
   threadCount,
-}: RunFileLintOptions): Promise<void> => {
+}: RunFileLintOptions): Promise<CliExitOutcome> => {
   if (!files.length) {
-    return;
+    return SUCCESS_EXIT;
   }
 
   let mdFiles = await loadMdFiles(files, excludeFiles, extensions);
@@ -159,8 +167,7 @@ export const runFileLint = async ({
 
   if (!mdFiles.length) {
     console.log("🎉 No markdown files to lint 🎉");
-    process.exit(0);
-    return;
+    return SUCCESS_EXIT;
   }
 
   const concurrencyDecision = await resolveAdaptiveConcurrency(
@@ -194,8 +201,12 @@ export const runFileLint = async ({
 
       console.log(consoleMessage);
 
-      const hasRuleFailures =
-        emitExecutionErrorsAndSetExitCode(actionableResults);
+      const executionErrorWarnings =
+        getExecutionErrorWarnings(actionableResults);
+      for (const warning of executionErrorWarnings) {
+        console.error(warning);
+      }
+      const hasRuleFailures = executionErrorWarnings.length > 0;
 
       if (
         shouldFailLint({
@@ -205,8 +216,7 @@ export const runFileLint = async ({
           warningCount,
         })
       ) {
-        setExitCode(1);
-        return;
+        return FAILURE_EXIT;
       }
     } else {
       await runTasksWithLimit(
@@ -226,8 +236,12 @@ export const runFileLint = async ({
       for (const warning of getUnappliedFixesWarnings(actionableResults)) {
         console.error(warning);
       }
-      const hasRuleFailures =
-        emitExecutionErrorsAndSetExitCode(actionableResults);
+      const executionErrorWarnings =
+        getExecutionErrorWarnings(actionableResults);
+      for (const warning of executionErrorWarnings) {
+        console.error(warning);
+      }
+      const hasRuleFailures = executionErrorWarnings.length > 0;
 
       if (isDev) {
         for (const line of getFixDevMetrics(allResults)) {
@@ -236,15 +250,16 @@ export const runFileLint = async ({
       }
 
       if (hasRuleFailures) {
-        return;
+        return FAILURE_EXIT;
       }
     }
   } catch (error) {
     const formatted = formatCoreError(error);
     console.error(formatted.handled ? formatted.message : error);
-    process.exit(1);
+    return FAILURE_EXIT;
   }
 
   const endTime = Date.now();
   console.log(`⌛️Done in ${endTime - startTime}ms.`);
+  return SUCCESS_EXIT;
 };

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -88,7 +88,7 @@ export const createProgram = (): Command => {
 
       if (stdin) {
         const content = readFileSync(process.stdin.fd, "utf8");
-        runStdinLint({
+        const outcome = runStdinLint({
           content,
           isDev,
           isFixMode,
@@ -96,10 +96,11 @@ export const createProgram = (): Command => {
           startTime,
           suppressWarnings,
         });
+        setExitCode(outcome.exitCode);
         return;
       }
 
-      await runFileLint({
+      const outcome = await runFileLint({
         excludeFiles,
         extensions,
         files,
@@ -111,6 +112,7 @@ export const createProgram = (): Command => {
         suppressWarnings,
         threadCount,
       });
+      setExitCode(outcome.exitCode);
     });
 
   return program;

--- a/src/utils/report-execution-errors.ts
+++ b/src/utils/report-execution-errors.ts
@@ -1,4 +1,3 @@
-import process from "process";
 import type { BatchLintItem } from "../types";
 import { sanitizeTerminalText } from "./sanitize-terminal";
 
@@ -38,42 +37,4 @@ export const getExecutionErrorWarnings = (items: BatchLintItem[]): string[] => {
   }
 
   return warnings;
-};
-
-/**
- * Writes one diagnostic line per execution error to the given stream and
- * returns true if any errors were reported. Callers should set
- * `process.exitCode = 1` (NOT call `process.exit(1)`) so stdout/stderr
- * finish flushing on pipe-based stdin flows.
- */
-export const reportExecutionErrors = (
-  items: BatchLintItem[],
-  stream: NodeJS.WritableStream = process.stderr
-): boolean => {
-  let wrote = false;
-  for (const line of getExecutionErrorWarnings(items)) {
-    stream.write(`${line}\n`);
-    wrote = true;
-  }
-  return wrote;
-};
-
-/**
- * Surfaces execution errors on the default stderr channel and sets
- * `process.exitCode = 1` when any are present. Setting the exit code (not
- * calling `process.exit(1)`) lets stdout/stderr finish flushing, which
- * matters for pipe-based stdin flows such as
- * `cat README.md | lint-md --stdin --fix > README.fixed.md`.
- *
- * Returns true when errors were present so the four CLI entry points can
- * also fold this into their existing exit decision without a second pass.
- */
-export const emitExecutionErrorsAndSetExitCode = (
-  items: BatchLintItem[]
-): boolean => {
-  const reported = reportExecutionErrors(items);
-  if (reported) {
-    process.exitCode = 1;
-  }
-  return reported;
 };


### PR DESCRIPTION
## Summary

- Make execution error utilities return diagnostic lines only.
- Make stdin and file flows return structured exit outcomes.
- Apply each outcome through process.exitCode at the CLI boundary.
- Remove direct process exit changes from both lint flows.

Closes #131.

## Behavior

Diagnostic order and output streams remain unchanged. Rule execution failures still return status 1.

Stdin fix writes Markdown before stderr diagnostics. The CLI uses process.exitCode for pipe-safe shutdown.

## Tests

Tests cover stdout, stderr, exit outcomes, timing, and rule execution failures.

## Validation

- npm run lint
- npm test -- --runInBand
- npm run test:package

All 183 tests pass.