### PR TITLE
refactor(batch): separate concurrency and file-size policies

### DIFF
--- a/__tests__/batch-lint.spec.ts
+++ b/__tests__/batch-lint.spec.ts
@@ -3,14 +3,9 @@ import { availableParallelism, tmpdir } from "os";
 import * as path from "path";
 import { Piscina } from "piscina";
 import type { LintMdRulesConfig } from "@lint-md/core";
-import {
-  STAT_CONCURRENCY_LIMIT,
-  batchLint,
-  getMaxFileSize,
-  keepLintItem,
-  resolveAdaptiveConcurrency,
-  runTasksWithLimit,
-} from "../src/utils/batch-lint";
+import { resolveAdaptiveConcurrency } from "../src/utils/adaptive-concurrency";
+import { batchLint, keepLintItem } from "../src/utils/batch-lint";
+import { STAT_CONCURRENCY_LIMIT, getMaxFileSize } from "../src/utils/file-stat";
 import type { BatchLintItem } from "../src/types";
 import { makeNotAppliedFix } from "./helpers/not-applied-fix";
 
@@ -25,41 +20,6 @@ const RULES_NO_EMPTY_LIST: LintMdRulesConfig = {
 };
 
 const TRIGGER_CONTENT = "1. hello\n2.\n";
-
-describe("runTasksWithLimit", () => {
-  test("respects concurrency limit", async () => {
-    let running = 0;
-    let maxRunning = 0;
-
-    const tasks = Array.from({ length: 10 }, () => async () => {
-      running++;
-      maxRunning = Math.max(maxRunning, running);
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      running--;
-      return true;
-    });
-
-    await runTasksWithLimit(tasks, 2);
-    expect(maxRunning).toBe(2);
-  });
-
-  test("preserves result order", async () => {
-    const tasks = [3, 1, 4, 1, 5].map((n) => async () => n);
-    const result = await runTasksWithLimit(tasks, 2);
-    expect(result).toEqual([3, 1, 4, 1, 5]);
-  });
-
-  test("handles empty task list", async () => {
-    const result = await runTasksWithLimit([], 3);
-    expect(result).toEqual([]);
-  });
-
-  test("limit greater than tasks count still works", async () => {
-    const tasks = [1, 2, 3].map((n) => async () => n * 10);
-    const result = await runTasksWithLimit(tasks, 10);
-    expect(result).toEqual([10, 20, 30]);
-  });
-});
 
 describe("batchLint", () => {
   let tmpDir: string;

--- a/__tests__/max-file-size.spec.ts
+++ b/__tests__/max-file-size.spec.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "os";
 import * as path from "path";
 import { execFileSync } from "child_process";
 import { filterFilesByMaxSize } from "../src/utils/filter-by-max-size";
-import { STAT_CONCURRENCY_LIMIT } from "../src/utils/batch-lint";
+import { STAT_CONCURRENCY_LIMIT } from "../src/utils/file-stat";
 import { parseSize } from "../src/utils/parse-size";
 
 const TSX = path.resolve(__dirname, "../node_modules/tsx/dist/cli.mjs");

--- a/__tests__/run-file-lint.spec.ts
+++ b/__tests__/run-file-lint.spec.ts
@@ -1,17 +1,19 @@
-import {
-  batchLint,
-  resolveAdaptiveConcurrency,
-  runTasksWithLimit,
-} from "../src/utils/batch-lint";
+import { resolveAdaptiveConcurrency } from "../src/utils/adaptive-concurrency";
+import { batchLint } from "../src/utils/batch-lint";
 import { filterFilesByMaxSize } from "../src/utils/filter-by-max-size";
 import { loadMdFiles } from "../src/utils/load-md-files";
+import { runTasksWithLimit } from "../src/utils/run-tasks-with-limit";
 import { safeWriteFile } from "../src/utils/safe-write-file";
 import { runFileLint } from "../src/cli/run-lint";
 import type { BatchLintItem } from "../src/types";
 
 jest.mock("../src/utils/batch-lint", () => ({
   batchLint: jest.fn(),
+}));
+jest.mock("../src/utils/adaptive-concurrency", () => ({
   resolveAdaptiveConcurrency: jest.fn(),
+}));
+jest.mock("../src/utils/run-tasks-with-limit", () => ({
   runTasksWithLimit: jest.fn(),
 }));
 jest.mock("../src/utils/filter-by-max-size", () => ({

--- a/__tests__/run-tasks-with-limit.spec.ts
+++ b/__tests__/run-tasks-with-limit.spec.ts
@@ -1,0 +1,43 @@
+import { runTasksWithLimit } from "../src/utils/run-tasks-with-limit";
+
+describe("runTasksWithLimit", () => {
+  test("respects concurrency limit", async () => {
+    let running = 0;
+    let maxRunning = 0;
+
+    const tasks = Array.from({ length: 10 }, () => async () => {
+      running++;
+      maxRunning = Math.max(maxRunning, running);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      running--;
+      return true;
+    });
+
+    await runTasksWithLimit(tasks, 2);
+    expect(maxRunning).toBe(2);
+  });
+
+  test("preserves result order", async () => {
+    const tasks = [3, 1, 4, 1, 5].map((value) => async () => value);
+
+    await expect(runTasksWithLimit(tasks, 2)).resolves.toEqual([3, 1, 4, 1, 5]);
+  });
+
+  test("handles an empty task list", async () => {
+    await expect(runTasksWithLimit([], 3)).resolves.toEqual([]);
+  });
+
+  test("supports a limit greater than the task count", async () => {
+    const tasks = [1, 2, 3].map((value) => async () => value * 10);
+
+    await expect(runTasksWithLimit(tasks, 10)).resolves.toEqual([10, 20, 30]);
+  });
+
+  test("propagates task rejection", async () => {
+    const failure = new Error("task failed");
+
+    await expect(
+      runTasksWithLimit([async () => 1, async () => Promise.reject(failure)], 2)
+    ).rejects.toBe(failure);
+  });
+});

--- a/src/cli/run-lint.ts
+++ b/src/cli/run-lint.ts
@@ -3,11 +3,8 @@ import { fixMarkdown, lintMarkdown } from "@lint-md/core";
 import type { LintMdRulesConfig } from "@lint-md/core";
 import type { BatchLintItem, ThreadCount } from "../types";
 import { safeWriteFile } from "../utils/safe-write-file";
-import {
-  batchLint,
-  resolveAdaptiveConcurrency,
-  runTasksWithLimit,
-} from "../utils/batch-lint";
+import { resolveAdaptiveConcurrency } from "../utils/adaptive-concurrency";
+import { batchLint } from "../utils/batch-lint";
 import { loadMdFiles } from "../utils/load-md-files";
 import { filterFilesByMaxSize } from "../utils/filter-by-max-size";
 import { formatCoreError } from "../utils/format-core-error";
@@ -18,6 +15,7 @@ import {
   getIncompleteFixWarnings,
 } from "../utils/report-incomplete-fixes";
 import { getExecutionErrorWarnings } from "../utils/report-execution-errors";
+import { runTasksWithLimit } from "../utils/run-tasks-with-limit";
 import {
   FAILURE_EXIT,
   SUCCESS_EXIT,

--- a/src/utils/adaptive-concurrency.ts
+++ b/src/utils/adaptive-concurrency.ts
@@ -1,0 +1,54 @@
+import { availableParallelism } from "os";
+import type { ThreadCount } from "../types";
+import { getMaxFileSize } from "./file-stat";
+
+const ONE_MIB = 1024 * 1024;
+const FIVE_MIB = 5 * ONE_MIB;
+const ADAPTIVE_MEDIUM_CAP = 2;
+const ADAPTIVE_LARGE_FILE_THRESHOLD = ONE_MIB;
+const ADAPTIVE_HUGE_FILE_THRESHOLD = FIVE_MIB;
+
+export interface AdaptiveConcurrencyDecision {
+  concurrency: number;
+  maxFileSize: number | null;
+  requestedConcurrency: number;
+}
+
+export const resolveAdaptiveConcurrency = async (
+  threadCount: ThreadCount,
+  mdFilePaths: string[]
+): Promise<AdaptiveConcurrencyDecision> => {
+  const requestedConcurrency =
+    typeof threadCount === "number" ? threadCount : availableParallelism();
+
+  if (mdFilePaths.length === 0) {
+    return {
+      concurrency: 0,
+      maxFileSize: threadCount === "auto" ? 0 : null,
+      requestedConcurrency,
+    };
+  }
+
+  if (typeof threadCount === "number") {
+    return {
+      concurrency: Math.min(Math.max(threadCount, 1), mdFilePaths.length),
+      maxFileSize: null,
+      requestedConcurrency,
+    };
+  }
+
+  const maxFileSize = await getMaxFileSize(mdFilePaths);
+
+  let limit = requestedConcurrency;
+  if (maxFileSize >= ADAPTIVE_HUGE_FILE_THRESHOLD) {
+    limit = 1;
+  } else if (maxFileSize >= ADAPTIVE_LARGE_FILE_THRESHOLD) {
+    limit = Math.min(limit, ADAPTIVE_MEDIUM_CAP);
+  }
+
+  return {
+    concurrency: Math.min(Math.max(limit, 1), mdFilePaths.length),
+    maxFileSize,
+    requestedConcurrency,
+  };
+};

--- a/src/utils/batch-lint.ts
+++ b/src/utils/batch-lint.ts
@@ -1,40 +1,10 @@
 import path from "path";
 import { existsSync } from "fs";
-import { stat } from "fs/promises";
-import { availableParallelism } from "os";
 import { Piscina } from "piscina";
 import type { LintMdRulesConfig } from "@lint-md/core";
-import type { BatchLintItem, LintWorkerOptions, ThreadCount } from "../types";
+import type { BatchLintItem, LintWorkerOptions } from "../types";
 import { isIncompleteFix } from "./report-incomplete-fixes";
-
-const ONE_MIB = 1024 * 1024;
-const FIVE_MIB = 5 * ONE_MIB;
-const ADAPTIVE_MEDIUM_CAP = 2;
-const ADAPTIVE_LARGE_FILE_THRESHOLD = ONE_MIB;
-const ADAPTIVE_HUGE_FILE_THRESHOLD = FIVE_MIB;
-// Upper bound on concurrent stat() fds in getMaxFileSize (see #80).
-export const STAT_CONCURRENCY_LIMIT = 128;
-
-export async function runTasksWithLimit<T>(
-  tasks: (() => Promise<T>)[],
-  limit: number
-): Promise<T[]> {
-  const results: T[] = [];
-  let index = 0;
-
-  async function runNext(): Promise<void> {
-    while (index < tasks.length) {
-      const i = index++;
-      results[i] = await tasks[i]();
-    }
-  }
-
-  const workers = Array.from({ length: Math.min(limit, tasks.length) }, () =>
-    runNext()
-  );
-  await Promise.all(workers);
-  return results;
-}
+import { runTasksWithLimit } from "./run-tasks-with-limit";
 
 const resolveWorkerFilename = (): string => {
   const compiled = path.resolve(__dirname, "./lint-worker.js");
@@ -42,72 +12,6 @@ const resolveWorkerFilename = (): string => {
     return compiled;
   }
   return path.resolve(__dirname, "../../lib/src/utils/lint-worker.js");
-};
-
-// getMaxFileSize() stats every file but bounds the in-flight stat calls to
-// STAT_CONCURRENCY_LIMIT via runTasksWithLimit, avoiding an N-fd filesystem
-// burst on very large repositories (see #80).
-// We bound concurrency rather than short-circuit on a >= 5 MiB file: this
-// function must return the TRUE maximum size, because src/lint-md.ts logs
-// `max file ${maxMiB} MiB` under --threads auto --dev. An early return would
-// make that log (and any future consumer) inaccurate. STAT_CONCURRENCY_LIMIT
-// is an empirical cap (the issue suggests 64/128), not benchmark-derived.
-export const getMaxFileSize = async (filePaths: string[]): Promise<number> => {
-  if (filePaths.length === 0) {
-    return 0;
-  }
-  const sizes = await runTasksWithLimit(
-    filePaths.map(
-      (filePath) => () => stat(filePath).then((stats) => stats.size)
-    ),
-    STAT_CONCURRENCY_LIMIT
-  );
-  return sizes.reduce((max, current) => (current > max ? current : max), 0);
-};
-
-export interface AdaptiveConcurrencyDecision {
-  concurrency: number;
-  maxFileSize: number | null;
-  requestedConcurrency: number;
-}
-
-export const resolveAdaptiveConcurrency = async (
-  threadCount: ThreadCount,
-  mdFilePaths: string[]
-): Promise<AdaptiveConcurrencyDecision> => {
-  const requestedConcurrency =
-    typeof threadCount === "number" ? threadCount : availableParallelism();
-
-  if (mdFilePaths.length === 0) {
-    return {
-      concurrency: 0,
-      maxFileSize: threadCount === "auto" ? 0 : null,
-      requestedConcurrency,
-    };
-  }
-
-  if (typeof threadCount === "number") {
-    return {
-      concurrency: Math.min(Math.max(threadCount, 1), mdFilePaths.length),
-      maxFileSize: null,
-      requestedConcurrency,
-    };
-  }
-
-  const maxFileSize = await getMaxFileSize(mdFilePaths);
-
-  let limit = requestedConcurrency;
-  if (maxFileSize >= ADAPTIVE_HUGE_FILE_THRESHOLD) {
-    limit = 1;
-  } else if (maxFileSize >= ADAPTIVE_LARGE_FILE_THRESHOLD) {
-    limit = Math.min(limit, ADAPTIVE_MEDIUM_CAP);
-  }
-
-  return {
-    concurrency: Math.min(Math.max(limit, 1), mdFilePaths.length),
-    maxFileSize,
-    requestedConcurrency,
-  };
 };
 
 // Keep a file's result when it has lint findings, or — in fix mode — when

--- a/src/utils/file-stat.ts
+++ b/src/utils/file-stat.ts
@@ -1,0 +1,21 @@
+import { stat } from "fs/promises";
+import { runTasksWithLimit } from "./run-tasks-with-limit";
+
+// Bound stat calls to prevent file descriptor bursts in large repositories.
+export const STAT_CONCURRENCY_LIMIT = 128;
+
+export const getMaxFileSize = async (filePaths: string[]): Promise<number> => {
+  if (filePaths.length === 0) {
+    return 0;
+  }
+
+  // Scan all files because dev output reports the true maximum size.
+  const sizes = await runTasksWithLimit(
+    filePaths.map(
+      (filePath) => () => stat(filePath).then((stats) => stats.size)
+    ),
+    STAT_CONCURRENCY_LIMIT
+  );
+
+  return sizes.reduce((max, current) => (current > max ? current : max), 0);
+};

--- a/src/utils/filter-by-max-size.ts
+++ b/src/utils/filter-by-max-size.ts
@@ -1,12 +1,10 @@
 import { stat } from "fs/promises";
-import { STAT_CONCURRENCY_LIMIT, runTasksWithLimit } from "./batch-lint";
+import { STAT_CONCURRENCY_LIMIT } from "./file-stat";
 import { formatBytes } from "./parse-size";
+import { runTasksWithLimit } from "./run-tasks-with-limit";
 
-// Drops Markdown files larger than limitBytes, emitting a stderr warning for
-// each skipped file. Stat concurrency is bounded by STAT_CONCURRENCY_LIMIT
-// (reused from batch-lint) so this does not reintroduce the N-fd stat burst
-// that #80 removed. A stat failure propagates upward, matching the existing
-// error boundary.
+// Keep the stat limit aligned with getMaxFileSize() to prevent fd bursts.
+// A stat failure propagates to the CLI error handler.
 export const filterFilesByMaxSize = async (
   mdFiles: string[],
   limitBytes: number

--- a/src/utils/run-tasks-with-limit.ts
+++ b/src/utils/run-tasks-with-limit.ts
@@ -1,0 +1,20 @@
+export async function runTasksWithLimit<T>(
+  tasks: (() => Promise<T>)[],
+  limit: number
+): Promise<T[]> {
+  const results: T[] = [];
+  let index = 0;
+
+  async function runNext(): Promise<void> {
+    while (index < tasks.length) {
+      const currentIndex = index++;
+      results[currentIndex] = await tasks[currentIndex]();
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, tasks.length) }, () =>
+    runNext()
+  );
+  await Promise.all(workers);
+  return results;
+}


### PR DESCRIPTION
## Summary

- Move bounded task scheduling into run-tasks-with-limit.ts.
- Move file stat limits and maximum size scanning into file-stat.ts.
- Move adaptive thread decisions into adaptive-concurrency.ts.
- Keep batch-lint.ts focused on worker lifecycle and result filtering.
- Remove reverse imports from file filtering and fix writing.

Closes #135.

## Behavior

This change keeps the current concurrency limits and output behavior. Numeric threads still skip file stat calls.

Automatic threads still scan each file once. Task results remain in input order.

## Validation

- npm run lint
- npm test -- --runInBand
- npm run test:package

All 184 tests pass.