### PR TITLE
refactor(core): centralize lint result adaptation

### DIFF
--- a/__tests__/to-batch-lint-item.spec.ts
+++ b/__tests__/to-batch-lint-item.spec.ts
@@ -1,0 +1,48 @@
+import type { LintMdFixResult, LintMdLintResult } from "@lint-md/core";
+import { toBatchLintItem } from "../src/utils/to-batch-lint-item";
+
+describe("toBatchLintItem", () => {
+  test("adapts a lint result", () => {
+    const result: LintMdLintResult = {
+      lintResult: [],
+      diagnostics: [],
+      fixedResult: null,
+      fixableErrorCount: 1,
+      fixableWarningCount: 2,
+      executionErrors: [],
+    };
+
+    expect(toBatchLintItem("doc.md", result)).toEqual({
+      path: "doc.md",
+      lintResult: [],
+      fixedResult: null,
+      fixableErrorCount: 1,
+      fixableWarningCount: 2,
+      executionErrors: [],
+    });
+  });
+
+  test("adapts a fix result", () => {
+    const fixedResult = {
+      result: "# Fixed\n",
+      notAppliedFixes: [],
+    };
+    const result: LintMdFixResult = {
+      lintResult: [],
+      diagnostics: [],
+      fixedResult,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0,
+      executionErrors: [],
+    };
+
+    expect(toBatchLintItem("doc.md", result)).toEqual({
+      path: "doc.md",
+      lintResult: [],
+      fixedResult,
+      fixableErrorCount: 0,
+      fixableWarningCount: 0,
+      executionErrors: [],
+    });
+  });
+});

--- a/src/cli/run-lint.ts
+++ b/src/cli/run-lint.ts
@@ -1,7 +1,7 @@
 import * as process from "process";
 import { fixMarkdown, lintMarkdown } from "@lint-md/core";
 import type { LintMdRulesConfig } from "@lint-md/core";
-import type { BatchLintItem, ThreadCount } from "../types";
+import type { ThreadCount } from "../types";
 import { safeWriteFile } from "../utils/safe-write-file";
 import { resolveAdaptiveConcurrency } from "../utils/adaptive-concurrency";
 import { batchLint } from "../utils/batch-lint";
@@ -16,6 +16,7 @@ import {
 } from "../utils/report-incomplete-fixes";
 import { getExecutionErrorWarnings } from "../utils/report-execution-errors";
 import { runTasksWithLimit } from "../utils/run-tasks-with-limit";
+import { toBatchLintItem } from "../utils/to-batch-lint-item";
 import {
   FAILURE_EXIT,
   SUCCESS_EXIT,
@@ -66,14 +67,7 @@ export const runStdinLint = ({
     try {
       const result = fixMarkdown(content, { rules });
       process.stdout.write(result.fixedResult?.result ?? content);
-      const stdinItem: BatchLintItem = {
-        path: "(stdin)",
-        lintResult: result.lintResult,
-        fixedResult: result.fixedResult,
-        fixableErrorCount: result.fixableErrorCount,
-        fixableWarningCount: result.fixableWarningCount,
-        executionErrors: result.executionErrors,
-      };
+      const stdinItem = toBatchLintItem("(stdin)", result);
       for (const warning of getIncompleteFixWarnings([stdinItem])) {
         console.error(warning);
       }
@@ -101,13 +95,7 @@ export const runStdinLint = ({
 
   try {
     const result = lintMarkdown(content, rules, false);
-    const stdinItem: BatchLintItem = {
-      path: "(stdin)",
-      lintResult: result.lintResult,
-      fixableErrorCount: result.fixableErrorCount,
-      fixableWarningCount: result.fixableWarningCount,
-      executionErrors: result.executionErrors,
-    };
+    const stdinItem = toBatchLintItem("(stdin)", result);
     const { consoleMessage, errorCount, warningCount } = getReportData([
       stdinItem,
     ]);

--- a/src/utils/lint-worker.ts
+++ b/src/utils/lint-worker.ts
@@ -1,6 +1,7 @@
 import { readFile } from "fs/promises";
 import { fixMarkdown, lintMarkdown } from "@lint-md/core";
 import type { LintWorkerOptions } from "../types";
+import { toBatchLintItem } from "./to-batch-lint-item";
 
 const lintWorker = async (options: LintWorkerOptions) => {
   const { filePath, rules, isFixMode } = options;
@@ -10,14 +11,7 @@ const lintWorker = async (options: LintWorkerOptions) => {
     ? fixMarkdown(content, { rules })
     : lintMarkdown(content, rules, false);
 
-  return {
-    path: filePath,
-    lintResult: result.lintResult,
-    fixedResult: result.fixedResult,
-    fixableErrorCount: result.fixableErrorCount,
-    fixableWarningCount: result.fixableWarningCount,
-    executionErrors: result.executionErrors,
-  };
+  return toBatchLintItem(filePath, result);
 };
 
 export default lintWorker;

--- a/src/utils/to-batch-lint-item.ts
+++ b/src/utils/to-batch-lint-item.ts
@@ -1,0 +1,14 @@
+import type { LintMdResult } from "@lint-md/core";
+import type { BatchLintItem } from "../types";
+
+export const toBatchLintItem = (
+  path: string,
+  result: LintMdResult
+): BatchLintItem => ({
+  path,
+  lintResult: result.lintResult,
+  fixedResult: result.fixedResult,
+  fixableErrorCount: result.fixableErrorCount,
+  fixableWarningCount: result.fixableWarningCount,
+  executionErrors: result.executionErrors,
+});


### PR DESCRIPTION
## Summary

- Add one adapter for core lint results.
- Use it for stdin lint and fix paths.
- Use it for worker lint and fix paths.
- Add direct adapter tests.

## Why

The CLI mapped the same core fields in three places.

A shared adapter keeps this boundary consistent.

The adapter excludes core diagnostics from BatchLintItem.

## Impact

CLI output and exit behavior stay unchanged.

Lint results now include fixedResult with a null value.

## Validation

- npm run typecheck
- Prettier check for changed files
- npm test -- --runInBand
- 24 test suites passed
- 186 tests passed

Closes #137