### PR TITLE
chore: upgrade @lint-md/core to 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Dependencies
+
+- upgrade `@lint-md/core` from `^2.3.0` to `^2.3.1`
+
 ## [2.2.4](https://github.com/lint-md/cli/compare/v2.2.3...v2.2.4) (2026-07-30)
 
 ### Dependencies

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     ]
   },
   "dependencies": {
-    "@lint-md/core": "^2.3.0",
+    "@lint-md/core": "^2.3.1",
     "chalk": "^4",
     "commander": "^9.4.1",
     "glob": "^13.0.6",


### PR DESCRIPTION
## Summary

- upgrade `@lint-md/core` from `^2.3.0` to `^2.3.1`
- document the dependency update in `CHANGELOG.md`

## Verification

- `npm test -- --runInBand`
- `npm run typecheck`

The existing untracked `.codegraph/`, `docs/`, and `out.md` files are not part of this PR.