### PR TITLE
feat(config): validate configuration shape

### DIFF
--- a/__tests__/configure.spec.ts
+++ b/__tests__/configure.spec.ts
@@ -68,6 +68,118 @@ describe("configuration validation", () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
+  test.each([
+    ["a string", '"lint-md"'],
+    ["an array", "[1, 2]"],
+    ["a number", "42"],
+    ["null", "null"],
+  ])("rejects a configuration whose root is %s", (_, content) => {
+    const configPath = path.join(tmpDir, "root.json");
+    writeFileSync(configPath, content, "utf8");
+
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error).toMatchObject({
+      code: "CONFIG_INVALID",
+      message: `[lint-md] Configure file '${configPath}' is invalid.`,
+    });
+    expect(error.detail).toBe("The configuration root must be a JSON object.");
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  test("rejects a non-array excludeFiles", () => {
+    const configPath = path.join(tmpDir, ".lintmdrc");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ excludeFiles: "node_modules" }),
+      "utf8"
+    );
+
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error.code).toBe("CONFIG_INVALID");
+    expect(error.detail).toContain(
+      '"excludeFiles" must be an array of strings.'
+    );
+  });
+
+  test("rejects a non-string element inside excludeFiles", () => {
+    const configPath = path.join(tmpDir, ".lintmdrc");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ excludeFiles: ["**/node_modules/**", 42] }),
+      "utf8"
+    );
+
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error.code).toBe("CONFIG_INVALID");
+    expect(error.detail).toContain('"excludeFiles[1]" must be a string.');
+  });
+
+  test("rejects a non-array extensions", () => {
+    const configPath = path.join(tmpDir, ".lintmdrc");
+    writeFileSync(configPath, JSON.stringify({ extensions: ".md" }), "utf8");
+
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error.code).toBe("CONFIG_INVALID");
+    expect(error.detail).toContain('"extensions" must be an array of strings.');
+  });
+
+  test.each([
+    ["an array", []],
+    ["a string", "strict"],
+    ["null", null],
+  ])("rejects rules that are %s", (_, rules) => {
+    const configPath = path.join(tmpDir, ".lintmdrc");
+    writeFileSync(configPath, JSON.stringify({ rules }), "utf8");
+
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error.code).toBe("CONFIG_INVALID");
+    expect(error.detail).toContain('"rules" must be an object.');
+  });
+
+  test("reports all shape errors in one error", () => {
+    const configPath = path.join(tmpDir, ".lintmdrc");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        excludeFiles: "node_modules",
+        extensions: ".md",
+        rules: [],
+      }),
+      "utf8"
+    );
+
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error.detail).toBe(
+      [
+        '"excludeFiles" must be an array of strings.',
+        '"extensions" must be an array of strings.',
+        '"rules" must be an object.',
+      ].join("\n")
+    );
+  });
+
+  test("accepts a well-shaped configuration and keeps defaults for absent fields", () => {
+    const configPath = path.join(tmpDir, ".lintmdrc");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ excludeFiles: ["dist/**"], extensions: [".md"] }),
+      "utf8"
+    );
+
+    expect(getLintConfig(configPath)).toEqual({
+      excludeFiles: ["dist/**"],
+      extensions: [".md"],
+      rules: {},
+    });
+  });
+
   test("uses the CPU count when threads are not specified", () => {
     expect(getThreadCount(undefined)).toBe(cpus().length);
     expect(getThreadCount(false)).toBe(cpus().length);

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -5,6 +5,65 @@ import { CliError } from "../cli/cli-error";
 import type { CLIConfig, ThreadCount } from "../types";
 import { parseSize } from "./parse-size";
 
+const collectStringArrayErrors = (field: string, value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [`"${field}" must be an array of strings.`];
+  }
+
+  return value
+    .map((item, index) =>
+      typeof item === "string" ? null : `"${field}[${index}]" must be a string.`
+    )
+    .filter((message): message is string => message !== null);
+};
+
+// Validates only fields owned by the CLI. Rule existence and rule option
+// schemas stay in @lint-md/core.
+export const validateConfigShape = (
+  value: unknown,
+  configPath: string
+): CLIConfig => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new CliError(
+      "CONFIG_INVALID",
+      `[lint-md] Configure file '${configPath}' is invalid.`,
+      "The configuration root must be a JSON object."
+    );
+  }
+
+  const config = value as Record<string, unknown>;
+  const errors: string[] = [];
+
+  if (config.excludeFiles !== undefined) {
+    errors.push(
+      ...collectStringArrayErrors("excludeFiles", config.excludeFiles)
+    );
+  }
+
+  if (config.extensions !== undefined) {
+    errors.push(...collectStringArrayErrors("extensions", config.extensions));
+  }
+
+  if (
+    config.rules !== undefined &&
+    (typeof config.rules !== "object" ||
+      config.rules === null ||
+      Array.isArray(config.rules))
+  ) {
+    errors.push('"rules" must be an object.');
+  }
+
+  if (errors.length > 0) {
+    throw new CliError(
+      "CONFIG_INVALID",
+      `[lint-md] Configure file '${configPath}' is invalid.`,
+      errors.join("\n")
+    );
+  }
+
+  return config as CLIConfig;
+};
+
 export const getLintConfig = (configFilePath?: string): Required<CLIConfig> => {
   if (configFilePath && !fs.existsSync(configFilePath)) {
     throw new CliError(
@@ -20,8 +79,10 @@ export const getLintConfig = (configFilePath?: string): Required<CLIConfig> => {
   if (!fs.existsSync(configPath)) {
     config = {};
   } else {
+    let parsedConfig: unknown;
+
     try {
-      config = JSON.parse(fs.readFileSync(configPath).toString());
+      parsedConfig = JSON.parse(fs.readFileSync(configPath).toString());
     } catch (error) {
       throw new CliError(
         "CONFIG_INVALID",
@@ -29,6 +90,8 @@ export const getLintConfig = (configFilePath?: string): Required<CLIConfig> => {
         error
       );
     }
+
+    config = validateConfigShape(parsedConfig, configPath);
   }
 
   return {


### PR DESCRIPTION
Closes #145

## 改动

在配置加载边界（`getLintConfig`）增加 schema 校验，JSON.parse 后立即验证字段类型。配置错误统一走 `CliError`（`CONFIG_INVALID`），不再等到 glob / extension 判断 / Core 调用时才暴露。

只校验 CLI 自己拥有的字段：

- config root -> object
- `excludeFiles` -> string[]
- `extensions` -> string[]
- `rules` -> object

rules 里面具体 rule 是否存在、rule 配置是否合法，继续交给 Core，CLI 不重复 Core 的 schema。

## 实现细节

- 新增 `validateConfigShape`：root 非对象直接报错；字段级错误收集后合并为一个 `CliError`，detail 为多行错误列表，一次看到全部问题
- parse 和 shape 校验分成两个 try 块：JSON 解析错误保留原有 SyntaxError detail，shape 错误不会被二次包装
- 显式 `null` 字段按类型错误处理（如 `"rules": null`）

## 测试

`__tests__/configure.spec.ts` 新增 9 个用例：

- root 为字符串/数组/数字/null 时拒绝
- `excludeFiles`、`extensions` 非数组
- 数组内非字符串元素（带下标定位）
- `rules` 为数组/字符串/null
- 多个错误一次性上报
- 合法配置正常加载并保留默认值

验证：typecheck 通过、prettier 通过、全量测试 25 suites / 202 tests 通过。