### PR TITLE
fix(files): make lint result ordering deterministic

### DIFF
--- a/__tests__/symlink-security.spec.ts
+++ b/__tests__/symlink-security.spec.ts
@@ -95,6 +95,20 @@ describe("symlink security", () => {
     expect(result).toEqual([]);
   });
 
+  test("loadMdFiles returns files in sorted order", async () => {
+    fs.writeFileSync(path.join(tmpDir, "b.md"), "# b");
+    fs.writeFileSync(path.join(tmpDir, "a.md"), "# a");
+    fs.writeFileSync(path.join(tmpDir, "c.md"), "# c");
+
+    const result = await loadMdFiles([path.join(tmpDir, "*.md")], []);
+
+    expect(result).toEqual([
+      path.join(tmpDir, "a.md"),
+      path.join(tmpDir, "b.md"),
+      path.join(tmpDir, "c.md"),
+    ]);
+  });
+
   test("loadMdFiles respects extensions filter", async () => {
     fs.writeFileSync(path.join(tmpDir, "a.md"), "# a");
     fs.writeFileSync(path.join(tmpDir, "b.txt"), "text");

--- a/src/utils/load-md-files.ts
+++ b/src/utils/load-md-files.ts
@@ -28,5 +28,7 @@ export const loadMdFiles = async (
     if (extensions.some((ext) => fullPath.endsWith(ext))) files.add(fullPath);
   }
 
-  return [...files];
+  // Sort so lint report order stays stable across OS, filesystem, and
+  // future glob traversal changes.
+  return [...files].sort();
 };


### PR DESCRIPTION
Closes #147

## 改动

`loadMdFiles()` 返回前对结果排序：

```typescript
return [...files].sort();
```

此前顺序依赖 glob / filesystem traversal 顺序，跨 OS、跨文件系统或 glob 未来行为变化时，CI 日志会出现无意义的顺序变化。现在 lint report 文件顺序稳定。

## 测试

`__tests__/symlink-security.spec.ts` 新增 1 个用例：

- 创建 b.md / a.md / c.md，断言返回 `[a.md, b.md, c.md]`

验证：typecheck 通过、prettier 通过、全量测试 25 suites / 203 tests 通过。