### PR TITLE
docs: sync CLI options with current behavior

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -75,11 +75,12 @@ The image runs as a non-root user by default. If the mounted directory has stric
 
 ## Common Options
 
-- `-c, --config [configure-file]`: use a configuration file, defaults to `./.lintmdrc`
+- `-c, --config <configure-file>`: use a configuration file, defaults to `./.lintmdrc`
 - `-f, --fix`: automatically fix fixable issues
-- `-t, --threads [thread-count]`: set the number of worker threads
+- `-t, --threads [thread-count]`: set the number of worker threads; use `auto` to adapt to file sizes, defaults to the CPU count
 - `-s, --suppress-warnings`: ignore warnings when deciding the exit code, which helps with gradual CI adoption
 - `-i, --stdin`: read Markdown content from standard input
+- `--max-file-size <size>`: skip Markdown files larger than `<size>` (e.g. `5mb`, `500kb`, `1gb`), with a warning to stderr
 - `-d, --dev`: enable development debug mode
 - `-v, --version`: print the current version
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,12 @@ docker run --rm \
 
 ## 常用参数
 
-- `-c, --config [configure-file]`：指定配置文件（默认 `./.lintmdrc`）
+- `-c, --config <configure-file>`：指定配置文件（默认 `./.lintmdrc`）
 - `-f, --fix`：自动修复可修复问题
-- `-t, --threads [thread-count]`：设置并发线程数
+- `-t, --threads [thread-count]`：设置并发线程数；传 `auto` 时按文件大小自适应，默认取 CPU 核数
 - `-s, --suppress-warnings`：忽略 warning 对退出码的影响（便于 CI 渐进接入）
 - `-i, --stdin`：从标准输入读取 Markdown 内容
+- `--max-file-size <size>`：跳过超过指定大小的 Markdown 文件（如 `5mb`、`500kb`、`1gb`），并向 stderr 输出警告
 - `-d, --dev`：开发调试模式
 - `-v, --version`：查看版本
 


### PR DESCRIPTION
Closes #149

## 改动

同步 `README.md` 与 `README.en-US.md` 的 Common Options，与 `createProgram()` 中的实际定义一致：

- `-c, --config [configure-file]` → `-c, --config <configure-file>`（commander 中参数必填，缺路径会直接报错）
- Common Options 补充 `--max-file-size <size>`（#83 已合入但文档未更新）
- `-t, --threads` 描述补充 `auto` 自适应与默认 CPU 核数（#79 已合入但文档未更新）

纯文档改动，无代码变化。