### PR TITLE
fix(cli): clarify empty file discovery output

### DIFF
--- a/__tests__/max-file-size.spec.ts
+++ b/__tests__/max-file-size.spec.ts
@@ -2,7 +2,7 @@ import { writeFileSync } from "fs";
 import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import * as path from "path";
-import { execFileSync, spawnSync } from "child_process";
+import { spawnSync } from "child_process";
 import { filterFilesByMaxSize } from "../src/utils/filter-by-max-size";
 import { STAT_CONCURRENCY_LIMIT } from "../src/utils/file-stat";
 import { parseSize } from "../src/utils/parse-size";

--- a/__tests__/max-file-size.spec.ts
+++ b/__tests__/max-file-size.spec.ts
@@ -2,7 +2,7 @@ import { writeFileSync } from "fs";
 import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import * as path from "path";
-import { execFileSync } from "child_process";
+import { execFileSync, spawnSync } from "child_process";
 import { filterFilesByMaxSize } from "../src/utils/filter-by-max-size";
 import { STAT_CONCURRENCY_LIMIT } from "../src/utils/file-stat";
 import { parseSize } from "../src/utils/parse-size";
@@ -120,20 +120,18 @@ describe("--max-file-size CLI behavior", () => {
   const runCli = (
     args: string[]
   ): { stdout: string; stderr: string; status: number } => {
-    try {
-      const stdout = execFileSync(process.execPath, [TSX, CLI, ...args], {
-        cwd: tmpDir,
-        encoding: "utf8",
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-      return { stdout, stderr: "", status: 0 };
-    } catch (e: any) {
-      return {
-        stdout: e.stdout ?? "",
-        stderr: e.stderr ?? "",
-        status: e.status ?? 1,
-      };
-    }
+    // spawnSync captures both streams for success and failure exits alike;
+    // execFileSync only exposes stderr through the thrown error.
+    const result = spawnSync(process.execPath, [TSX, CLI, ...args], {
+      cwd: tmpDir,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return {
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      status: result.status ?? 1,
+    };
   };
 
   test("invalid size (1.5mb) -> exit 1 + stderr", () => {
@@ -194,15 +192,17 @@ describe("--max-file-size CLI behavior", () => {
     expect(after).toBe(largeOriginal);
   });
 
-  test("all files filtered out -> No markdown files message", () => {
+  test("all files filtered out -> size-filter message, exit 0", () => {
     const large = path.join(tmpDir, "large.md");
     writeFileSyncHelper(
       large,
       `${Buffer.alloc(200 * 1024, "a")}\n${VIOLATION}`
     );
-    const { status, stdout } = runCli([large, "--max-file-size", "100kb"]);
+    const { status, stderr } = runCli([large, "--max-file-size", "100kb"]);
     expect(status).toBe(0);
-    expect(stdout).toContain("🎉 No markdown files to lint 🎉");
+    expect(stderr).toContain(
+      "[lint-md] No Markdown files remain after file-size filtering."
+    );
   });
 
   test("works together with --threads auto on remaining files", () => {

--- a/__tests__/run-file-lint.spec.ts
+++ b/__tests__/run-file-lint.spec.ts
@@ -94,17 +94,32 @@ describe("runFileLint", () => {
     expect(mockLoadMdFiles).not.toHaveBeenCalled();
   });
 
-  test("returns success when file discovery returns no matches", async () => {
+  test("reports unmatched patterns and returns success when discovery finds no files", async () => {
     mockLoadMdFiles.mockResolvedValue([]);
-    const exit = jest.spyOn(process, "exit").mockImplementation((() => {
-      throw new Error("process.exit");
-    }) as never);
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
 
-    const outcome = await runFileLint(makeOptions());
+    const outcome = await runFileLint(makeOptions({ files: ["docs/*.md"] }));
 
-    expect(console.log).toHaveBeenCalledWith("🎉 No markdown files to lint 🎉");
-    expect(exit).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[lint-md] No Markdown files matched: "docs/*.md"'
+    );
     expect(outcome).toEqual({ exitCode: 0 });
+    expect(mockFilterFilesByMaxSize).not.toHaveBeenCalled();
+  });
+
+  test("reports size filtering when all discovered files are skipped", async () => {
+    mockLoadMdFiles.mockResolvedValue(["large.md"]);
+    mockFilterFilesByMaxSize.mockResolvedValue([]);
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+
+    const outcome = await runFileLint(makeOptions({ maxFileSizeBytes: 100 }));
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[lint-md] No Markdown files remain after file-size filtering."
+    );
+    expect(outcome).toEqual({ exitCode: 0 });
+    expect(mockResolveAdaptiveConcurrency).not.toHaveBeenCalled();
+    expect(mockBatchLint).not.toHaveBeenCalled();
   });
 
   test("filters files before concurrency and batch decisions", async () => {

--- a/__tests__/run-file-lint.spec.ts
+++ b/__tests__/run-file-lint.spec.ts
@@ -107,6 +107,17 @@ describe("runFileLint", () => {
     expect(mockFilterFilesByMaxSize).not.toHaveBeenCalled();
   });
 
+  test("escapes quotes inside unmatched patterns", async () => {
+    mockLoadMdFiles.mockResolvedValue([]);
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+
+    await runFileLint(makeOptions({ files: ['docs/"draft".md'] }));
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[lint-md] No Markdown files matched: "docs/\\"draft\\".md"'
+    );
+  });
+
   test("reports size filtering when all discovered files are skipped", async () => {
     mockLoadMdFiles.mockResolvedValue(["large.md"]);
     mockFilterFilesByMaxSize.mockResolvedValue([]);

--- a/src/cli/run-lint.ts
+++ b/src/cli/run-lint.ts
@@ -17,6 +17,7 @@ import {
 import { getExecutionErrorWarnings } from "../utils/report-execution-errors";
 import { runTasksWithLimit } from "../utils/run-tasks-with-limit";
 import { summarizeLintResults } from "../utils/summarize-lint-results";
+import { sanitizeTerminalText } from "../utils/sanitize-terminal";
 import { toBatchLintItem } from "../utils/to-batch-lint-item";
 import {
   FAILURE_EXIT,
@@ -146,13 +147,25 @@ export const runFileLint = async ({
 
   let mdFiles = await loadMdFiles(files, excludeFiles, extensions);
 
-  if (maxFileSizeBytes !== null) {
-    mdFiles = await filterFilesByMaxSize(mdFiles, maxFileSizeBytes);
+  // Empty discovery stays a success so local usage keeps exit 0.
+  // The message names the cause instead of a generic "no files" note.
+  if (!mdFiles.length) {
+    const patterns = files
+      .map((file) => `"${sanitizeTerminalText(file)}"`)
+      .join(", ");
+    console.error(`[lint-md] No Markdown files matched: ${patterns}`);
+    return SUCCESS_EXIT;
   }
 
-  if (!mdFiles.length) {
-    console.log("🎉 No markdown files to lint 🎉");
-    return SUCCESS_EXIT;
+  if (maxFileSizeBytes !== null) {
+    mdFiles = await filterFilesByMaxSize(mdFiles, maxFileSizeBytes);
+
+    if (!mdFiles.length) {
+      console.error(
+        "[lint-md] No Markdown files remain after file-size filtering."
+      );
+      return SUCCESS_EXIT;
+    }
   }
 
   const concurrencyDecision = await resolveAdaptiveConcurrency(

--- a/src/cli/run-lint.ts
+++ b/src/cli/run-lint.ts
@@ -151,7 +151,7 @@ export const runFileLint = async ({
   // The message names the cause instead of a generic "no files" note.
   if (!mdFiles.length) {
     const patterns = files
-      .map((file) => `"${sanitizeTerminalText(file)}"`)
+      .map((file) => JSON.stringify(sanitizeTerminalText(file)))
       .join(", ");
     console.error(`[lint-md] No Markdown files matched: ${patterns}`);
     return SUCCESS_EXIT;


### PR DESCRIPTION
Closes #151

## 改动

不改变退出码，把 "为什么没有 lint 到文件" 说清楚。区分两种情况：

**glob / 扩展名过滤后没有匹配**（带输入 pattern，直接暴露拼错的 glob）：

```
[lint-md] No Markdown files matched: "docs/**/*.markdwon"
```

**`--max-file-size` 把所有文件都跳过了**：

```
[lint-md] No Markdown files remain after file-size filtering.
```

细节：

- 两种消息都走 stderr，stdout 保持只输出报告；pattern 文本经 `sanitizeTerminalText` 清理
- exit code 保持 0，本地使用与 CI 行为完全兼容

## 测试

- `run-file-lint.spec.ts`：未匹配 → 断言新消息 + pattern + exit 0；size filter 清空 → 断言独立消息且不再进入并发/batch 阶段
- `max-file-size.spec.ts`：e2e 用例改为断言新的 size-filter 消息；顺带修复 `runCli` helper 只在失败路径捕获 stderr 的问题（改用 `spawnSync`）

验证：typecheck 通过、prettier 通过、全量测试 25 suites / 204 tests 通过。