### PR TITLE
chore: upgrade TypeScript to 5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "prettier": "^2.7.1",
     "ts-jest": "^29.4.0",
     "tsx": "^4.22.4",
-    "typescript": "^4.8.4"
+    "typescript": "^5.9.0"
   },
   "overrides": {
     "js-yaml": "^3.15.0"


### PR DESCRIPTION
Closes #155

## 改动

```diff
- "typescript": "^4.8.4"
+ "typescript": "^5.9.0"
```

分阶段升级的 PR A：只动 TypeScript 一项，零源码修改。TS 5.9 是 5.x 最后一代成熟版本，不会立刻触发 TS 6 的 deprecated config 问题。

注：`package-lock.json` 在本仓库被 gitignore，不随 PR 提交。

## 验证（TypeScript 5.9.3 实测）

| 检查项 | 结果 |
| --- | --- |
| `npm run typecheck` | 通过，零类型错误 |
| prettier check | 通过 |
| `npm test -- --runInBand` | 25 suites / 205 tests 通过 |
| `npm run test:package` | 通过（pack → 全局安装 → version → stdin lint → 文件 lint → --fix → 复检） |

## 后续

- PR B：单独现代化 tsconfig（评估 `moduleResolution: "Node"` 与 `baseUrl: "./"`）
- PR C：tsconfig 清理后再升 TypeScript 6.0