### PR TITLE
chore(tsconfig): remove deprecated compiler options

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "jest --no-cache",
     "pretest": "npm run build",
-    "build:cjs": "tsc -p tsconfig.json --target ESNext --module commonjs --outDir lib",
+    "build:cjs": "tsc -p tsconfig.json --target ESNext --outDir lib",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "format": "prettier --write \"src/**/*.ts\" \"__tests__/**/*.ts\"",
     "lint": "npm run typecheck && prettier --check \"src/**/*.ts\" \"__tests__/**/*.ts\"",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "removeComments": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "isolatedModules": true,
     "types": [
       "jest",
       "node"
@@ -13,7 +14,6 @@
     "allowJs": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "baseUrl": "./",
     "outDir": "lib"
   },
   "include": [


### PR DESCRIPTION
Closes #157

## 改动

`tsconfig.json`：

```diff
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
+    "isolatedModules": true,
     ...
-    "baseUrl": "./",
```

`package.json`：

```diff
-    "build:cjs": "tsc -p tsconfig.json --target ESNext --module commonjs --outDir lib",
+    "build:cjs": "tsc -p tsconfig.json --target ESNext --outDir lib",
```

## 理由

- `baseUrl: "./"`：无 `paths` 别名、无 root-anchored 导入，纯死配置 → 删除
- `moduleResolution: "Node"`（node10）：TS 6 deprecated、TS 7 移除。TS 5.x 下 CJS module 的唯一配套就是 node10，因此整体切到 `NodeNext`
- package.json 无 `"type": "module"`，NodeNext 下 .ts 仍按 CommonJS 输出（已验证 `lib/src/lint-md.js` 使用 `require()`/`exports.`）
- `isolatedModules: true`：ts-jest 对 hybrid module kind 的要求，本身也是现代推荐项
- `build:cjs` 去掉 `--module commonjs`：与 tsconfig NodeNext 冲突；flag 冗余

### emit 不变 ≠ 解析语义不变

区分两件事：

1. **输出格式**：仍然 CommonJS，无变化
2. **模块解析模型**：确实现代化了。NodeNext 理解现代 Node 的 package.json `exports`、条件导出等解析规则，node10 不理解。这正是本 PR 想要的变化

现有 typecheck、测试和真实打包安装（test:package）证明当前依赖树在新解析模型下没有问题。

## 验证（零源码修改）

| 检查项 | 结果 |
| --- | --- |
| `npm run typecheck` | 通过 |
| `npm test -- --runInBand` | 25 suites / 205 tests 通过，ts-jest 警告消失 |
| 输出格式 | `lib/` 仍为 CommonJS |
| `npm run test:package` | 通过 |

PR C（TypeScript 5.9 → 6.0）现在没有 deprecated config 阻碍了。
