### PR TITLE
refactor(types): enable noImplicitAny

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^22.9.3",
+    "@types/text-table": "^0.2.5",
     "jest": "^30.0.0",
     "prettier": "^2.7.1",
     "ts-jest": "^29.4.7",

--- a/src/utils/format-lint-report.ts
+++ b/src/utils/format-lint-report.ts
@@ -42,7 +42,8 @@ export const formatLintReport = (summary: LintSummary): string => {
         ];
       }),
       {
-        align: ["", "r", "l"],
+        // text-table treats undefined like "" (default alignment).
+        align: [undefined, "r", "l"],
         stringLength(value) {
           return stripAnsi(value).length;
         },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,6 @@
     // import of ../package.json makes the effective root the project
     // directory, which preserves the lib/src/** emit layout.
     "rootDir": "./",
-    // TS 6 flips the effective noImplicitAny default to true. Pinned to keep
-    // the upgrade diff behavior-preserving; see format-lint-report.ts for the
-    // known implicit-any sites awaiting cleanup.
-    "noImplicitAny": false,
     "types": [
       "jest",
       "node"


### PR DESCRIPTION
Closes #161

## 改动

```diff
  "package.json"
+    "@types/text-table": "^0.2.5"

  "tsconfig.json"
-    // TS 6 flips the effective noImplicitAny default to true. Pinned to keep
-    // the upgrade diff behavior-preserving; see format-lint-report.ts for the
-    // known implicit-any sites awaiting cleanup.
-    "noImplicitAny": false,

  "src/utils/format-lint-report.ts"
-        align: ["", "r", "l"],
+        // text-table treats undefined like "" (default alignment).
+        align: [undefined, "r", "l"],
```

## 根因说明

之前预估的 6 个隐式 any 是同一个根因：`text-table` 无类型声明 → `table()` 返回 `any` → 下游 `.split()/.map()/.replace()` 回调参数全部隐式 any。安装官方 `@types/text-table` 后，整条链获得上下文类型，只剩一个真实错误：

`@types/text-table` 把 `align` 收紧为 `"l" | "r" | "c" | "." | null | undefined`，代码里的 `""` 不在联合内。已核对 text-table 运行时源码（index.js 只比较 `'.'` / `'r'` / `'c'`）：`undefined` 与 `""` 走同一条默认分支，替换可证等价、零行为变化。

callback 参数无需手写注解——类型全部来自 DT 声明的上下文推导。

## 验证

| 检查项 | 结果 |
| --- | --- |
| `npm run typecheck`（noImplicitAny 开启） | 通过 |
| `npm test -- --runInBand` | 25 suites / 205 tests 通过 |
| `npm run build` + emit 检查 | 通过，仍为 CJS |
| `npm run test:package` | 通过 |