### PR TITLE
feat(config): reject unknown configuration fields

### DIFF
--- a/__tests__/configure.spec.ts
+++ b/__tests__/configure.spec.ts
@@ -165,6 +165,94 @@ describe("configuration validation", () => {
     );
   });
 
+  test("rejects an unknown configuration field", () => {
+    const configPath = path.join(tmpDir, ".lintmdrc");
+    writeFileSync(configPath, JSON.stringify({ extensons: [".md"] }), "utf8");
+
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error.code).toBe("CONFIG_INVALID");
+    expect(error.detail).toContain('Unknown configuration field "extensons".');
+  });
+
+  test("rejects unknown fields without fuzzy suggestions", () => {
+    const configPath = path.join(tmpDir, ".lintmdrc");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ excludeFile: ["dist/**"] }),
+      "utf8"
+    );
+
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error.detail).toContain(
+      'Unknown configuration field "excludeFile".'
+    );
+    expect(error.detail).not.toContain("Did you mean");
+  });
+
+  test("reports all unknown fields", () => {
+    const configPath = path.join(tmpDir, ".lintmdrc");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ threads: 2, extensionsX: [], extra: true }),
+      "utf8"
+    );
+
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error.detail).toBe(
+      [
+        'Unknown configuration field "threads".',
+        'Unknown configuration field "extensionsX".',
+        'Unknown configuration field "extra".',
+      ].join("\n")
+    );
+  });
+
+  test("aggregates unknown-field and type errors", () => {
+    const configPath = path.join(tmpDir, ".lintmdrc");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ extensons: [".md"], excludeFiles: "node_modules" }),
+      "utf8"
+    );
+
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error.detail).toBe(
+      [
+        '"excludeFiles" must be an array of strings.',
+        'Unknown configuration field "extensons".',
+      ].join("\n")
+    );
+  });
+
+  test("sanitizes control characters in unknown field names", () => {
+    const configPath = path.join(tmpDir, ".lintmdrc");
+    writeFileSync(configPath, '{"evil\\u001B[31mfield": 1}', "utf8");
+
+    const error = captureCliError(() => getLintConfig(configPath));
+
+    expect(error.detail).toContain('Unknown configuration field "evil');
+    expect(error.detail).not.toContain("\u001B");
+  });
+
+  test("does not reject fields inside rules", () => {
+    const configPath = path.join(tmpDir, ".lintmdrc");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        rules: { "some-future-core-rule": { option: true } },
+      }),
+      "utf8"
+    );
+
+    expect(getLintConfig(configPath)).toMatchObject({
+      rules: { "some-future-core-rule": { option: true } },
+    });
+  });
+
   test("accepts a well-shaped configuration and keeps defaults for absent fields", () => {
     const configPath = path.join(tmpDir, ".lintmdrc");
     writeFileSync(

--- a/src/utils/configure.ts
+++ b/src/utils/configure.ts
@@ -4,6 +4,13 @@ import * as path from "path";
 import { CliError } from "../cli/cli-error";
 import type { CLIConfig, ThreadCount } from "../types";
 import { parseSize } from "./parse-size";
+import { sanitizeTerminalText } from "./sanitize-terminal";
+
+const KNOWN_CONFIG_FIELDS: ReadonlySet<string> = new Set([
+  "excludeFiles",
+  "extensions",
+  "rules",
+]);
 
 const collectStringArrayErrors = (field: string, value: unknown): string[] => {
   if (!Array.isArray(value)) {
@@ -51,6 +58,18 @@ export const validateConfigShape = (
       Array.isArray(config.rules))
   ) {
     errors.push('"rules" must be an object.');
+  }
+
+  // Unknown root fields are rejected, not ignored: a typo like "extensons"
+  // would otherwise silently fall back to defaults. Field names come from
+  // user JSON, so sanitize before embedding in terminal output.
+  for (const field of Object.keys(config)) {
+    if (KNOWN_CONFIG_FIELDS.has(field)) continue;
+    errors.push(
+      `Unknown configuration field ${JSON.stringify(
+        sanitizeTerminalText(field)
+      )}.`
+    );
   }
 
   if (errors.length > 0) {


### PR DESCRIPTION
Closes #163

## 改动

`validateConfigShape` 增加未知顶层字段检查。已知字段：`excludeFiles`、`extensions`、`rules`，其余一律 `CONFIG_INVALID` + exit 1：

```
[lint-md] Configure file '/path/.lintmdrc' is invalid.
Unknown configuration field "extensons".
```

细节：

- 错误聚合沿用 #146 模式：先报字段类型错误，再报 unknown fields，一次全部输出
- 不做 fuzzy suggestion（"Did you mean"），先把严格 schema 做对
- 未知字段名来自用户 JSON，输出前经 `sanitizeTerminalText` 清理（与 core 配置错误的终端伪造防护一致）
- **rules 内部字段不校验**，继续交给 `@lint-md/core`，保持 CLI / Core 职责边界

## 测试（新增 6 个）

- 单个 unknown field → 报错并带字段名
- 近似拼写只报 unknown、无 "Did you mean"
- 多个 unknown → 全部上报
- unknown + 类型错误 → 聚合为一个 detail
- 字段名含控制字符 → 被转义，无裸 ESC 输出
- rules 内部含未知规则配置 → 正常接受

## 验证

| 检查项 | 结果 |
| --- | --- |
| `npm run typecheck` | 通过 |
| `npm test -- --runInBand` | 25 suites / 211 tests 通过 |
| `npm run test:package` | 通过 |
| 手动 CLI 验证 | typo 场景与聚合场景输出符合预期，exit 1 |