### PR TITLE
fix(cli): reject file arguments with --stdin

### DIFF
--- a/__tests__/cli.spec.ts
+++ b/__tests__/cli.spec.ts
@@ -119,4 +119,47 @@ describe("cli tests", () => {
     await expect(main(["node", "lint-md"])).rejects.toThrow("process.exit");
     expect(mockExit).toHaveBeenCalledWith(0);
   });
+
+  test("rejects file arguments combined with --stdin", async () => {
+    const runFileLint = jest.fn().mockResolvedValue({ exitCode: 0 });
+    const runStdinLint = jest.fn().mockReturnValue({ exitCode: 0 });
+    jest.doMock("../src/cli/run-lint", () => ({
+      runFileLint,
+      runStdinLint,
+    }));
+    const mockError = jest.spyOn(console, "error").mockImplementation();
+    const { runCli } = require("../src/lint-md");
+
+    process.exitCode = undefined;
+    runCli(["node", "lint-md", "fixture.md", "--stdin"]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[lint-md] --stdin cannot be used with file arguments."
+      )
+    );
+    expect(runStdinLint).not.toHaveBeenCalled();
+    expect(runFileLint).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("rejects the -i short form combined with file arguments", async () => {
+    const runFileLint = jest.fn().mockResolvedValue({ exitCode: 0 });
+    const runStdinLint = jest.fn().mockReturnValue({ exitCode: 0 });
+    jest.doMock("../src/cli/run-lint", () => ({
+      runFileLint,
+      runStdinLint,
+    }));
+    const mockError = jest.spyOn(console, "error").mockImplementation();
+    const { runCli } = require("../src/lint-md");
+
+    process.exitCode = undefined;
+    runCli(["node", "lint-md", "-i", "fixture.md"]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(runStdinLint).not.toHaveBeenCalled();
+    expect(runFileLint).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
 });

--- a/src/cli/cli-error.ts
+++ b/src/cli/cli-error.ts
@@ -4,7 +4,8 @@ export type CliErrorCode =
   | "CONFIG_NOT_FOUND"
   | "CONFIG_INVALID"
   | "INVALID_THREADS"
-  | "INVALID_MAX_FILE_SIZE";
+  | "INVALID_MAX_FILE_SIZE"
+  | "CONFLICTING_INPUT";
 
 export class CliError extends Error {
   constructor(

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -76,6 +76,15 @@ export const createProgram = (): Command => {
       const isFixMode = Boolean(fix);
       const isDev = Boolean(dev);
 
+      // Fail before touching stdin or the file list so neither input mode
+      // starts on a command that mixes both.
+      if (stdin && files.length > 0) {
+        throw new CliError(
+          "CONFLICTING_INPUT",
+          "[lint-md] --stdin cannot be used with file arguments."
+        );
+      }
+
       if (isDev) {
         console.log(`dev -- version: ${version}, ${new Date().toString()}`);
       }


### PR DESCRIPTION
Closes #165

## 改动

`--stdin` 与文件参数同时出现时报错退出，不再静默忽略 files：

```
[lint-md] --stdin cannot be used with file arguments.
```

- 新增 `CliErrorCode`：`CONFLICTING_INPUT`
- 冲突检查放在 action 最前：读取 stdin、file discovery、配置加载都未开始，冲突命令零副作用
- `-i` 短形式同样覆盖（commander 归一化为 stdin）

## 测试（新增 2 个）

单元层直接证明"不读取 stdin、不执行 file lint"：

- `fixture.md --stdin` → 报错信息 + `runStdinLint` 未调用 + `runFileLint` 未调用 + exit 1
- `-i fixture.md` → 同上

`--stdin` 单独与 files 单独的正常路径由既有 213 个用例覆盖，另手动复验。

## 验证

| 检查项 | 结果 |
| --- | --- |
| `npm run typecheck` | 通过 |
| `npm test -- --runInBand` | 25 suites / 213 tests 通过 |
| 手动 CLI：`--stdin` 单独 / 文件单独 / 两者混合 | exit 0 / 0 / 1，符合预期 |