### PR TITLE
fix(cli): avoid executing lint setup when no input is provided

### DIFF
--- a/__tests__/cli.spec.ts
+++ b/__tests__/cli.spec.ts
@@ -120,6 +120,20 @@ describe("cli tests", () => {
     expect(mockExit).toHaveBeenCalledWith(0);
   });
 
+  test("skips lint setup when no input is provided", async () => {
+    const getLintConfig = jest.fn();
+    jest.doMock("../src/utils/configure", () => ({ getLintConfig }));
+    const mockExit = jest.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as never);
+    const { main } = require("../src/lint-md");
+
+    await expect(main(["node", "lint-md"])).rejects.toThrow("process.exit");
+
+    expect(getLintConfig).not.toHaveBeenCalled();
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
   test("rejects file arguments combined with --stdin", async () => {
     const runFileLint = jest.fn().mockResolvedValue({ exitCode: 0 });
     const runStdinLint = jest.fn().mockReturnValue({ exitCode: 0 });

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -76,6 +76,13 @@ export const createProgram = (): Command => {
       const isFixMode = Boolean(fix);
       const isDev = Boolean(dev);
 
+      // No input at all: show help before touching config, threads, or
+      // stdin. A broken .lintmdrc must not turn bare "lint-md" into a
+      // config error.
+      if (!files.length && !stdin) {
+        program.help();
+      }
+
       // Fail before touching stdin or the file list so neither input mode
       // starts on a command that mixes both.
       if (stdin && files.length > 0) {
@@ -130,11 +137,6 @@ export const createProgram = (): Command => {
 export const main = async (argv: string[] = process.argv): Promise<void> => {
   const program = createProgram();
   await program.parseAsync(argv);
-
-  const isStdin = argv.includes("--stdin") || argv.includes("-i");
-  if (!program.args.length && !isStdin) {
-    program.help();
-  }
 };
 
 export const runCli = (argv: string[] = process.argv): void => {


### PR DESCRIPTION
Closes #167

## 改动

无输入判断从 `parseAsync()` 之后移到 action 最前面：

```typescript
// No input at all: show help before touching config, threads, or
// stdin. A broken .lintmdrc must not turn bare "lint-md" into a
// config error.
if (!files.length && !stdin) {
  program.help();
}
```

`main()` 里 parseAsync 之后的原检查删除，保持单一判断来源。

## 行为变化

| 场景 | 之前 | 现在 |
| --- | --- | --- |
| `lint-md`（配置正常） | 跑一遍空 setup 后显示 help | 直接显示 help |
| `lint-md`（`.lintmdrc` 损坏） | CONFIG_INVALID 报错 exit 1 | 显示 help，exit 0 |

## 测试（新增 1 个）

- 无输入时 `getLintConfig` 未被调用、`process.exit(0)` 被调用——证明 lint setup 完全没有开始

既有 "main shows help when no input is provided" 用例不变通过；`--stdin` 与文件路径的行为由 #166 的用例覆盖。

## 验证

| 检查项 | 结果 |
| --- | --- |
| `npm test -- --runInBand` | 25 suites / 214 tests 通过 |
| 手动：坏 `.lintmdrc` + 裸 `lint-md` | 输出 Usage/Options，exit 0 |
| `npm run test:package` | 通过 |