### PR TITLE
fix(cli): reject file-only options with --stdin

### DIFF
--- a/__tests__/cli.spec.ts
+++ b/__tests__/cli.spec.ts
@@ -176,4 +176,84 @@ describe("cli tests", () => {
     expect(runFileLint).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(1);
   });
+
+  test("rejects --threads combined with --stdin before validating its value", async () => {
+    const runFileLint = jest.fn().mockResolvedValue({ exitCode: 0 });
+    const runStdinLint = jest.fn().mockReturnValue({ exitCode: 0 });
+    jest.doMock("../src/cli/run-lint", () => ({
+      runFileLint,
+      runStdinLint,
+    }));
+    const mockError = jest.spyOn(console, "error").mockImplementation();
+    const { runCli } = require("../src/lint-md");
+
+    process.exitCode = undefined;
+    runCli(["node", "lint-md", "--stdin", "--threads", "abc"]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[lint-md] --threads cannot be used with --stdin."
+      )
+    );
+    expect(mockError).not.toHaveBeenCalledWith(
+      expect.stringContaining("INVALID_THREADS")
+    );
+    expect(runStdinLint).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("rejects --max-file-size combined with --stdin", async () => {
+    const runFileLint = jest.fn().mockResolvedValue({ exitCode: 0 });
+    const runStdinLint = jest.fn().mockReturnValue({ exitCode: 0 });
+    jest.doMock("../src/cli/run-lint", () => ({
+      runFileLint,
+      runStdinLint,
+    }));
+    const mockError = jest.spyOn(console, "error").mockImplementation();
+    const { runCli } = require("../src/lint-md");
+
+    process.exitCode = undefined;
+    runCli(["node", "lint-md", "--stdin", "--max-file-size", "5mb"]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[lint-md] --max-file-size cannot be used with --stdin."
+      )
+    );
+    expect(runStdinLint).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("aggregates all file-only options rejected with --stdin", async () => {
+    const runFileLint = jest.fn().mockResolvedValue({ exitCode: 0 });
+    const runStdinLint = jest.fn().mockReturnValue({ exitCode: 0 });
+    jest.doMock("../src/cli/run-lint", () => ({
+      runFileLint,
+      runStdinLint,
+    }));
+    const mockError = jest.spyOn(console, "error").mockImplementation();
+    const { runCli } = require("../src/lint-md");
+
+    process.exitCode = undefined;
+    runCli([
+      "node",
+      "lint-md",
+      "--stdin",
+      "--threads",
+      "4",
+      "--max-file-size",
+      "5mb",
+    ]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(mockError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[lint-md] The following options cannot be used with --stdin:\n--threads\n--max-file-size"
+      )
+    );
+    expect(runStdinLint).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
 });

--- a/__tests__/threads-validation.spec.ts
+++ b/__tests__/threads-validation.spec.ts
@@ -7,7 +7,7 @@ const TSX = path.resolve(__dirname, "../node_modules/tsx/dist/cli.mjs");
 const CLI = path.resolve(__dirname, "../src/lint-md.ts");
 
 describe("--threads validation across CLI paths", () => {
-  test("stdin + --threads abc → exit 1 + stderr", () => {
+  test("stdin + --threads abc → rejected as a conflicting option, exit 1", () => {
     try {
       execFileSync(
         process.execPath,
@@ -21,7 +21,9 @@ describe("--threads validation across CLI paths", () => {
       throw new Error("should have thrown");
     } catch (e: any) {
       expect(e.status).toBe(1);
-      expect(e.stderr).toContain("--threads must be a positive integer");
+      expect(e.stderr).toContain(
+        "[lint-md] --threads cannot be used with --stdin."
+      );
     }
   });
 
@@ -42,17 +44,24 @@ describe("--threads validation across CLI paths", () => {
     }
   });
 
-  test("stdin + --threads auto → does not exit 1 (numeric validation skipped)", () => {
-    const result = execFileSync(
-      process.execPath,
-      [TSX, CLI, "--stdin", "--threads", "auto"],
-      {
-        input: "# title\n",
-        encoding: "utf8",
-        stdio: ["pipe", "pipe", "pipe"],
-      }
-    );
-    expect(result).toContain("Done in");
+  test("stdin + --threads auto → rejected as a conflicting option, exit 1", () => {
+    try {
+      execFileSync(
+        process.execPath,
+        [TSX, CLI, "--stdin", "--threads", "auto"],
+        {
+          input: "# title\n",
+          encoding: "utf8",
+          stdio: ["pipe", "pipe", "pipe"],
+        }
+      );
+      throw new Error("should have thrown");
+    } catch (e: any) {
+      expect(e.status).toBe(1);
+      expect(e.stderr).toContain(
+        "[lint-md] --threads cannot be used with --stdin."
+      );
+    }
   });
 
   test("files + --threads auto → exit 0 on a small markdown file", () => {

--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -92,6 +92,31 @@ export const createProgram = (): Command => {
         );
       }
 
+      // --threads and --max-file-size only affect file linting. Reject them
+      // here instead of silently accepting options that would do nothing.
+      const conflictingOptions = [
+        [threads !== undefined, "--threads"],
+        [maxFileSize !== undefined, "--max-file-size"],
+      ]
+        .filter(([present]) => present)
+        .map(([, name]) => name);
+
+      if (stdin && conflictingOptions.length === 1) {
+        throw new CliError(
+          "CONFLICTING_INPUT",
+          `[lint-md] ${conflictingOptions[0]} cannot be used with --stdin.`
+        );
+      }
+
+      if (stdin && conflictingOptions.length > 1) {
+        throw new CliError(
+          "CONFLICTING_INPUT",
+          `[lint-md] The following options cannot be used with --stdin:\n${conflictingOptions.join(
+            "\n"
+          )}`
+        );
+      }
+
       if (isDev) {
         console.log(`dev -- version: ${version}, ${new Date().toString()}`);
       }


### PR DESCRIPTION
Closes #169

## 改动

`--threads`、`--max-file-size` 与 `--stdin` 同时出现时拒绝，不再静默接受无效参数：

单个冲突：

```
[lint-md] --threads cannot be used with --stdin.
```

两个同时出现，一次聚合：

```
[lint-md] The following options cannot be used with --stdin:
--threads
--max-file-size
```

细节：

- 复用 `CONFLICTING_INPUT` 错误码，检查放在 action 前段（配置加载、stdin 读取之前），冲突命令零副作用
- `--threads abc` 现在报冲突而不是 INVALID_THREADS——参数根本不会使用，值校验已无意义
- stdin 下仍合法：`--config`、`--fix`、`--dev`、`--suppress-warnings`

## 测试（新增 3 个，更新 2 个）

新增：

- `--stdin --threads abc` → 冲突消息（且断言不是 INVALID_THREADS）
- `--stdin --max-file-size 5mb` → 单项冲突
- 两个选项同时出现 → 聚合输出

更新 `threads-validation.spec.ts` 两个用例：它们锁定的正是本 PR 有意移除的旧契约（stdin 下走数值校验 / auto 跳过校验）。

## 验证

| 检查项 | 结果 |
| --- | --- |
| `npm run typecheck` | 通过 |
| `npm test -- --runInBand` | 25 suites / 217 tests 通过 |
| 手动：单项 / 聚合 / 合法组合（`--stdin --fix --suppress-warnings`） | exit 1 / 1 / 0，符合预期 |