### PR TITLE
fix(cli): clarify suppress-warnings help text

### DIFF
--- a/src/lint-md.ts
+++ b/src/lint-md.ts
@@ -50,7 +50,7 @@ export const createProgram = (): Command => {
     )
     .option(
       "-s, --suppress-warnings",
-      "suppress all warnings, that means warnings will not block CI（抑制所有警告，这意味着警告不会阻止 CI）"
+      "do not let warnings affect the exit code（忽略 warning 对退出码的影响）"
     )
     .option(
       "-i, --stdin",


### PR DESCRIPTION
Closes #171

## 改动

```diff
     .option(
       "-s, --suppress-warnings",
-      "suppress all warnings, that means warnings will not block CI（抑制所有警告，这意味着警告不会阻止 CI）"
+      "do not let warnings affect the exit code（忽略 warning 对退出码的影响）"
     )
```

## 理由

旧文案 "suppress all warnings" 与实现不符：warning 仍然显示，只是不参与退出码判定。README 的描述一直是准确的，本 PR 让 CLI help 与 README、实际实现对齐。

- 零行为变化
- 不改 option 名，无 breaking change
- 1 行 diff

## 验证

- `--help` 输出新文案
- typecheck 通过、25 suites / 217 tests 全绿