### PR TITLE
chore: prepare 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [2.3.0](https://github.com/lint-md/cli/compare/v2.2.5...v2.3.0) (2026-08-22)
+
+### Features
+
+- validate CLI configuration shape ([#146](https://github.com/lint-md/cli/pull/146))
+- reject unknown configuration fields ([#164](https://github.com/lint-md/cli/pull/164))
+
+### Bug Fixes
+
+- make lint result ordering deterministic ([#148](https://github.com/lint-md/cli/pull/148))
+- clarify empty file discovery output ([#152](https://github.com/lint-md/cli/pull/152))
+- reject file arguments with `--stdin` ([#166](https://github.com/lint-md/cli/pull/166))
+- avoid lint setup when no input is provided ([#168](https://github.com/lint-md/cli/pull/168))
+- reject file-only options with `--stdin` ([#170](https://github.com/lint-md/cli/pull/170))
+- clarify the `--suppress-warnings` help text ([#172](https://github.com/lint-md/cli/pull/172))
+
+### Refactoring
+
+- enable `noImplicitAny` ([#162](https://github.com/lint-md/cli/pull/162))
+
+### Tooling
+
+- align ts-jest with Jest 30 support ([#154](https://github.com/lint-md/cli/pull/154))
+- upgrade TypeScript from `^4.8.4` to `^6.0.3` in two steps ([#156](https://github.com/lint-md/cli/pull/156), [#160](https://github.com/lint-md/cli/pull/160))
+- modernize the tsconfig to NodeNext resolution ([#158](https://github.com/lint-md/cli/pull/158))
+
+### Documentation
+
+- sync CLI options with current behavior ([#150](https://github.com/lint-md/cli/pull/150))
+
+### CI/CD
+
+- release on version tags ([#144](https://github.com/lint-md/cli/pull/144))
+
 ## [2.2.5](https://github.com/lint-md/cli/compare/v2.2.4...v2.2.5) (2026-08-10)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lint-md/cli",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "CLI tool to lint your markdown file for Chinese.",
   "bin": {
     "lint-md": "lib/src/lint-md.js"


### PR DESCRIPTION
Closes #173

## 内容

基于 90af47a（2.2.5 release）之后的实际 15 个 commit 整理：

- `package.json`: `2.2.5` → `2.3.0`
- `CHANGELOG.md` 新增 `[2.3.0]` 章节（compare 链接、日期 2026-08-22），分节：Features / Bug Fixes / Refactoring / Tooling / Documentation / CI/CD，条目均带 PR 链接

与草稿的差异：#162 归入 Refactoring（原 commit 类型）；TypeScript 两步升级合并为一条 Tooling 条目引用 #156/#160。

## 验证

| 检查项 | 结果 |
| --- | --- |
| `npm run typecheck` | 通过 |
| `npm test -- --runInBand` | 25 suites / 217 tests 通过 |
| `lint-md --version` | 输出 `2.3.0` |
| `npm run test:package` | pack → 安装 → lint/fix 全链路通过 |

合并后按 #144 的 workflow 打 `v2.3.0` tag 即触发发布。