### PR TITLE
test(cli): make error assertions ANSI-safe

### DIFF
--- a/__tests__/cli.spec.ts
+++ b/__tests__/cli.spec.ts
@@ -1,3 +1,5 @@
+import stripAnsi from "strip-ansi";
+
 describe("cli tests", () => {
   const originalArgv = process.argv;
   const originalExitCode = process.exitCode;
@@ -248,10 +250,10 @@ describe("cli tests", () => {
     ]);
     await new Promise<void>((resolve) => setImmediate(resolve));
 
-    expect(mockError).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "[lint-md] The following options cannot be used with --stdin:\n--threads\n--max-file-size"
-      )
+    // chalk wraps each line of a multiline message in ANSI codes, so
+    // compare against the stripped text.
+    expect(stripAnsi(String(mockError.mock.calls[0][0]))).toBe(
+      "[lint-md] The following options cannot be used with --stdin:\n--threads\n--max-file-size"
     );
     expect(runStdinLint).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(1);


### PR DESCRIPTION
Closes #175

## 改动

`cli.spec.ts` 的多行聚合错误断言改为剥离 ANSI 后精确匹配：

```diff
+import stripAnsi from "strip-ansi";
+
     await new Promise<void>((resolve) => setImmediate(resolve));
 
-    expect(mockError).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "[lint-md] The following options cannot be used with --stdin:\n--threads\n--max-file-size"
-      )
-    );
+    // chalk wraps each line of a multiline message in ANSI codes, so
+    // compare against the stripped text.
+    expect(stripAnsi(String(mockError.mock.calls[0][0]))).toBe(
+      "[lint-md] The following options cannot be used with --stdin:\n--threads\n--max-file-size"
+    );
```

## 说明

- 根因：`formatCliError()` 的 `chalk.red()` 对多行字符串在每个换行处插入 close/reopen 控制码，`stringContaining` 在 FORCE_COLOR 环境必然失败
- 已复现确认：`FORCE_COLOR=1` 下旧断言失败，且 chalk 输出确实含 `\u001b[39m\n\u001b[31m`
- cli.spec.ts 其余错误断言均为单行消息，ANSI 码只包首尾，不受影响——不扩大改动范围
- 生产代码零变化（#170 实现没问题）
- `strip-ansi` 本就是项目依赖，无新增包

## 验证

| 检查项 | 结果 |
| --- | --- |
| `jest cli.spec`（默认环境） | 21/21 通过 |
| `FORCE_COLOR=1 jest cli.spec`（复现条件） | 21/21 通过 |
| 全量（默认 + FORCE_COLOR=1） | 各 25 suites / 217 tests 通过 |