### PR TITLE
test(package): allow package smoke test during npm publish dry-run

### DIFF
--- a/scripts/test-package.mjs
+++ b/scripts/test-package.mjs
@@ -44,6 +44,9 @@ try {
   const packOutput = run("npm", [
     "pack",
     "--json",
+    // The outer `npm publish --dry-run` propagates npm_config_dry_run into
+    // this script; force a real tarball for the local smoke test.
+    "--dry-run=false",
     "--pack-destination",
     temporaryDirectory,
   ]);
@@ -70,6 +73,8 @@ try {
     "--omit=dev",
     "--no-audit",
     "--no-fund",
+    // Same npm_config_dry_run propagation; force a real installation.
+    "--dry-run=false",
     tarball,
   ]);
 


### PR DESCRIPTION
Closes #177

## 改动

`scripts/test-package.mjs` 的两个嵌套 npm 命令显式覆盖 dry-run：

```diff
   const packOutput = run("npm", [
     "pack",
     "--json",
+    // The outer `npm publish --dry-run` propagates npm_config_dry_run into
+    // this script; force a real tarball for the local smoke test.
+    "--dry-run=false",
     "--pack-destination",
     temporaryDirectory,
   ]);
```

```diff
   run("npm", [
     "install",
     "--global",
     "--prefix",
     installPrefix,
     "--omit=dev",
     "--no-audit",
     "--no-fund",
+    // Same npm_config_dry_run propagation; force a real installation.
+    "--dry-run=false",
     tarball,
   ]);
```

## 根因

外层 `npm publish --dry-run` 通过 `npm_config_dry_run=true` 环境变量传播给所有嵌套 npm 命令：

1. 内层 `npm pack` 变 dry-run → 不生成 tarball（用户报告的报错）
2. 只修 pack 后暴露第二层：内层 `npm install --global` 同样变空操作 → `bin/lint-md` ENOENT

两处都显式 `--dry-run=false` 后，smoke test 在任何调用路径下都执行真实打包安装；外层 publish 仍是 dry-run，不会上传。

## 验证

| 检查项 | 结果 |
| --- | --- |
| `npm run test:package`（直接调用） | 通过 |
| `npm publish --dry-run`（完整 prepublishOnly 链） | 通过，输出 `+ @lint-md/cli@2.3.0` |
| 临时目录清理 | `/tmp/lint-md-package-*` 无残留 |