### PR TITLE
docs(changelog): record test fixes in the 2.3.0 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
 
 - enable `noImplicitAny` ([#162](https://github.com/lint-md/cli/pull/162))
 
+### Tests
+
+- make CLI error assertions ANSI-safe ([#176](https://github.com/lint-md/cli/pull/176))
+- run the package smoke test during `npm publish --dry-run` ([#178](https://github.com/lint-md/cli/pull/178))
+
 ### Tooling
 
 - align ts-jest with Jest 30 support ([#154](https://github.com/lint-md/cli/pull/154))


### PR DESCRIPTION
## 内容

2.3.0 章节新增 Tests 小节，补记两个发布准备之后合入的测试修复：

```markdown
### Tests

- make CLI error assertions ANSI-safe ([#176](https://github.com/lint-md/cli/pull/176))
- run the package smoke test during `npm publish --dry-run` ([#178](https://github.com/lint-md/cli/pull/178))
```

**注意合并顺序：#178 仍是 OPEN 状态，本 PR 应在 #178 合并之后再合**，否则 changelog 会先于实现出现。