### PR TITLE
fix: refresh Docker badge on master

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,14 @@
 name: docker
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "package.json"
+      - ".github/workflows/docker.yml"
   pull_request:
     paths:
       - "Dockerfile"


### PR DESCRIPTION
## Summary

- Run the Docker workflow after relevant changes reach `master`.
- Keep the Docker badge aligned with the current `master` state.

## Validation

- `actionlint .github/workflows/docker.yml`
- `git diff --check`

## Security

- This change does not include logs or secrets.
- No redaction was required.