### PR TITLE
fix(concurrency): stop scheduling new tasks after first failure

### DIFF
--- a/__tests__/run-tasks-with-limit.spec.ts
+++ b/__tests__/run-tasks-with-limit.spec.ts
@@ -40,4 +40,46 @@ describe("runTasksWithLimit", () => {
       runTasksWithLimit([async () => 1, async () => Promise.reject(failure)], 2)
     ).rejects.toBe(failure);
   });
+
+  test("stops scheduling new tasks after the first rejection", async () => {
+    const failure = new Error("task failed");
+    const started: number[] = [];
+    let markSecondStarted!: () => void;
+    let releaseSecond!: () => void;
+    const secondStarted = new Promise<void>((resolve) => {
+      markSecondStarted = resolve;
+    });
+    const secondRelease = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    const tasks = [
+      async () => {
+        started.push(0);
+        await secondStarted;
+        throw failure;
+      },
+      async () => {
+        started.push(1);
+        markSecondStarted();
+        await secondRelease;
+        return 1;
+      },
+      async () => {
+        started.push(2);
+        return 2;
+      },
+      async () => {
+        started.push(3);
+        return 3;
+      },
+    ];
+
+    const run = runTasksWithLimit(tasks, 2);
+
+    await expect(run).rejects.toBe(failure);
+    releaseSecond();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(started).toEqual([0, 1]);
+  });
 });

--- a/src/utils/run-tasks-with-limit.ts
+++ b/src/utils/run-tasks-with-limit.ts
@@ -4,11 +4,18 @@ export async function runTasksWithLimit<T>(
 ): Promise<T[]> {
   const results: T[] = [];
   let index = 0;
+  let failed = false;
 
   async function runNext(): Promise<void> {
-    while (index < tasks.length) {
+    while (!failed && index < tasks.length) {
       const currentIndex = index++;
-      results[currentIndex] = await tasks[currentIndex]();
+
+      try {
+        results[currentIndex] = await tasks[currentIndex]();
+      } catch (error) {
+        failed = true;
+        throw error;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Stop workers from scheduling new tasks after the first rejection.
- Allow tasks that already started to finish.
- Add a deterministic regression test for the failure sequence.

## Cause

`Promise.all()` propagated the rejection. Other workers continued to read the shared task index.

## Validation

- `npm run lint`
- `npm test -- --runInBand`
- 218 tests passed.
- `git diff --check`

## Security

- This change does not include logs or secrets.
- No redaction was required.